### PR TITLE
Skills catalogue prefactor, /90s de-indexing, and orientation docs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,85 @@
+# Portfolio
+
+Andrew Furusawa's personal portfolio at `andrewfurusawa.dev` — a Next.js App Router site that renders the same professional substance through more than one presentation, including a soft-secret 90s-styled experiment.
+
+## Language
+
+### The site
+
+**Portfolio**:
+The whole site at `andrewfurusawa.dev`, across every presentation of it.
+_Avoid_: website, homepage (the homepage is one route within it)
+
+**Presentation**:
+A complete visual rendering of the portfolio's substance with its own route, chrome, and type. Today: the modern presentation at `/` and the experiment at `/90s`.
+_Avoid_: theme, skin, variant
+
+**Experiment**:
+The `/90s` presentation — a parallel, soft-secret take on the portfolio, shipped and maintained alongside the modern one rather than replacing it.
+_Avoid_: prototype (that is throwaway), demo, v2 site
+
+**Soft secret**:
+Reachable by anyone who knows the URL, but never advertised — no inbound links from the modern presentation, and absent from search results. Absence from search is the goal, not absence from crawlers; this is not authentication, and nothing here is private.
+_Avoid_: secret, hidden, private, gated
+
+### Substance and chrome
+
+**Substance**:
+The real portfolio content — identity, skills, work, contact. Substance is shared across presentations; chrome is not.
+_Avoid_: content (too broad), copy
+
+**Chrome**:
+The decorative frame a presentation wraps around substance — banners, nav bevels, panes, dividers, footer, texture. Chrome carries the period character; substance stays readable underneath it.
+_Avoid_: styling, decoration, theme
+
+**Theater**:
+Chrome that imitates a working period feature without one behind it — the hit counter counts nothing, and there is no guestbook. Theater is non-interactive by policy.
+_Avoid_: fake feature, mock, stub
+
+**Kitsch**:
+The deliberate period excess of the experiment's chrome, held on a short leash so it never costs readability or WCAG 2.2 AA.
+
+**Neon Cyber Basement**:
+The experiment's dark visual identity — pure neons on near-black, pixel-terminal body type, an Impact-class display face. Its light counterpart, **Neon Cyber Dayroom**, is a reference mood only and is not a shipped presentation.
+
+### Work
+
+**Project**:
+One piece of shipped professional work, named and attributable — an app, a product, a platform. Substance, not chrome: shared across presentations as the same data. Distinct from the repository this site lives in, which is never called a project in domain terms.
+_Avoid_: case study (promises a narrative this site does not tell), portfolio piece, app
+
+**Featured work**:
+The curated handful of projects a presentation chooses to show — a section label, never a property of a project. Capped at three by design: a project is not marked featured, it is simply in the set or absent from it.
+_Avoid_: selected work, highlights, portfolio
+
+### Skills and notes
+
+**Skill**:
+One named technology in the portfolio's professional skills list, shared by every presentation as the same data. Carries an explicit `slug` — its durable identity, independent of the display name.
+_Avoid_: technology, tool, tag
+
+**Skill note**:
+First-person writing about one skill within the experiment — where it was used, why it fit at the time, what it taught. One note per skill at most, and only for skills with something to say. Deliberately not documentation: a note is considered and partial, never a reference.
+_Avoid_: dispatch (collides with the Redux/React reducer verb), post (implies a dated feed), README (promises reference documentation, not experience)
+
+**Publish set**:
+The skills that have a note. Always a strict subset of the catalogue, and expected to stay one — a skill without a note is the normal case, not a gap.
+_Avoid_: published posts, live pages
+
+**Catalogue**:
+The full list of skills as displayed — every skill appears, whether or not a note exists for it. Only skills in the publish set are links.
+_Avoid_: index, registry (a registry is the set of pages, not of skills)
+
+**Category**:
+A named grouping of skills in the catalogue. Every skill has exactly one. The experiment's directory sections the tile wall by it; other presentations may ignore it.
+_Avoid_: tag (implies many), folder, bucket
+
+### Planning
+
+**Wayfinder map**:
+A charted route from a loose idea to a named destination, held as an issue on the tracker with its decisions as child tickets. The active one is summarised in [`PLAN.md`](PLAN.md).
+_Avoid_: roadmap, plan, epic
+
+**Spec**:
+An implementable package of locked decisions, published as a GitHub issue via `/to-spec`. It is the source of truth for taste and scope until the change ships; after ship, the code wins. Prototypes and research notes yield to it. v1's file under `docs/design/` is historical only.
+_Avoid_: design spec, design doc, PRD (the issue *is* the spec; do not keep a second copy in `docs/design/`)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,55 @@
+# Plan
+
+**Objective:** produce a v2 **spec** (GitHub issue via `/to-spec`) for the `/90s` experiment — hi-fi kitsch chrome, skill notes at `/90s/skills/[slug]`, a light featured-work strip, mailto-only contact — charted as [Wayfinder: /90s hi-fi kitsch and skill-note content spec](https://github.com/afurusawa/andrewfurusawa/issues/35). This effort produces **decisions**, then one tracker spec. It does not build the upgrade, cut over the public homepage, or write a new `docs/design/` file.
+
+**Architecture, route ownership, and data contracts:** see `docs/MAP.md`, `docs/agent-context-map.md` (path inventory), and `docs/adr/`. Do not duplicate those essays here.
+
+**The issue tracker is canonical.** This file is the readable snapshot; where the two disagree, GitHub wins. `docs/agents/issue-tracker.md` records how maps, tickets, blocking, and the frontier are expressed here.
+
+_Last updated: 2026-08-12._
+
+## Active Slice
+
+**In flight:** nothing. Decision tickets are closed.
+
+**Terminology:** the writing unit is a **skill note**. "Dispatch" is retired everywhere except the two closed research tickets, whose titles are left as historical record. The implementable package is a **spec** issue, not a `docs/design/` file.
+
+**Takeable now:** destination handoff — run `/to-spec` to write the v2 spec issue from the closed map. Not a new wayfinder child.
+
+## Backlog
+
+None. The map waits on that spec issue before it can close.
+
+**Not yet sharp enough to ticket:** performance budget for hub and note pages against the live portfolio; a brand name for the space beyond the path `/90s`; the first multi-skill publish batch after the single example.
+
+**Ruled out of this effort:** homepage cutover or linking `/90s` from the live nav; changing the modern homepage skills UI (shared `category` does not force it); guestbook or public message walls; server-backed contact form or hit counter; a first-class light theme; autoplay audio; drafting the full first batch of skill notes; any CMS as the authoring source of truth.
+
+## Completed Ledger
+
+One line per finished decision. Detail lives in the linked ticket — zoom there rather than restating it here.
+
+### Current effort — [/90s v2 spec](https://github.com/afurusawa/andrewfurusawa/issues/35)
+
+- [Research Next.js MDX/content patterns for /90s skill posts](https://github.com/afurusawa/andrewfurusawa/issues/36) — `@next/mdx` + top-level `content/skills/*.mdx` + `gray-matter` frontmatter + `generateStaticParams` with `dynamicParams = false`; `next-mdx-remote` archived, `output: export` ruled out, MDX config is app-global. Findings on `research/nextjs-mdx-90s-skill-posts`.
+- [Research soft-secret SEO for nested /90s skill post routes](https://github.com/afurusawa/andrewfurusawa/issues/37) — today's `Disallow: /90s` and `noindex` cancel each other; use `X-Robots-Tag` on `/90s` and `/90s/:path*` with self-referential canonicals per segment. Findings on `research/soft-secret-seo-90s`.
+- [Define the skill-note content model for /90s](https://github.com/afurusawa/andrewfurusawa/issues/38) — the unit is a **skill note**, one per skill and only where there's something to say; "dispatch" retired. `Skill` gains an explicit `slug`; `content/skills/<slug>.md`, filename is the association. Frontmatter `summary` + optional `updated`, no `draft`. Three fixed H2s: Where I used it / Why it fit / What it taught me.
+- [Define Featured work strip model for /90s hub](https://github.com/afurusawa/andrewfurusawa/issues/39) — shared `featuredWork.ts`; cap of 3, no floor; stack entries are skill slugs; all three items link-free. Nav becomes About · Work · Skills · Contact.
+- [Decide skills catalogue vs note set data relationship](https://github.com/afurusawa/andrewfurusawa/issues/42) — `allSkills` moves to `app/config/skills.ts` as `{ slug, name, icon }`; one build-time join; orphan notes throw. 35 slugs locked. `category` later added by the directory prototype.
+- [Prototype /90s skills directory UI treatments](https://github.com/afurusawa/andrewfurusawa/issues/43) — category-grouped icon-tile wall; publish-set carried by tile treatment; `category` ships; VT323 is display-only. See [Fix the category taxonomy for the skills catalogue](https://github.com/afurusawa/andrewfurusawa/issues/50).
+- [Define About and hub voice/microcopy for /90s v2](https://github.com/afurusawa/andrewfurusawa/issues/40) — garnish only in information-free chrome; hub `<h1>` is `Andrew Furusawa`; four locked strings (About, Skills helper, Work helper, 404).
+- [Prototype /90s skill note page shell](https://github.com/afurusawa/andrewfurusawa/issues/44) — Document Window: one bordered article on the existing stage; no sticky TOC. On `prototype/90s-skill-note-shell`.
+- [Choose the example skill for the v2 sample note](https://github.com/afurusawa/andrewfurusawa/issues/45) — **Ionic** (`ionic`).
+- [Produce the example skill note for the v2 spec](https://github.com/afurusawa/andrewfurusawa/issues/46) — Ionic example note drafted from MilkTracker and Blossom/GroConnect. [Final draft](https://github.com/afurusawa/andrewfurusawa/issues/46#issuecomment-5266039742).
+- [Decide the Markdown/MDX rendering toolchain for /90s skill notes](https://github.com/afurusawa/andrewfurusawa/issues/48) — local server-side plain-Markdown pipeline (`gray-matter` + `unified`/`remark`/`rehype`); no JSX/GFM/raw HTML.
+- [Lock the /90s soft-secret discoverability policy](https://github.com/afurusawa/andrewfurusawa/issues/49) — crawl-allowed + header `noindex, nofollow`; `/90s` unnamed in `robots.txt`; per-route experiment unfurls, no share image; inbound-link test.
+- [Fix the category taxonomy for the skills catalogue](https://github.com/afurusawa/andrewfurusawa/issues/50) — closed union Frontend · Mobile · Backend · Tooling · Design; no singletons (Testing merged into Tooling, Shadcn moved to Frontend); `/` ignores the field.
+- [Define hi-fi chrome inventory and assets for /90s v2](https://github.com/afurusawa/andrewfurusawa/issues/41) — fidelity-only v1 pack: required 88×31 badges + tape UC, CSS starfield, hub-only, static, ≤40KB; no new motifs.
+- [Lock /90s v2 design-spec packaging and map-done criteria](https://github.com/afurusawa/andrewfurusawa/issues/47) — no v2 `docs/design/` file; implementable package is a `/to-spec` GitHub issue; map closes when that issue exists.
+
+### [/90s v1 design spec](https://github.com/afurusawa/andrewfurusawa/issues/15) — closed
+
+Delivered `docs/design/90s-experiment-spec.md` and shipped as `app/90s/` in [#34](https://github.com/afurusawa/andrewfurusawa/pull/34). Locked and still binding until v2 supersedes them: single-page `/90s`; About · Skills · Contact; shared profile links and skills data; dark theme only; cosmetic theater only; soft-secret discoverability; WCAG 2.2 AA; hybrid variant D shell at a ~64rem stage; mood-board colour lock with VT323 body type.
+
+### [Portfolio audit and framework decision](https://github.com/afurusawa/andrewfurusawa/issues/1) — closed
+
+Stay on **Next.js** — no material Astro advantage evidenced; reconsider only if a like-for-like proof clears the initial-JS gate. Set the performance budgets and the canonical `https://andrewfurusawa.dev` domain now recorded in `docs/MAP.md`.

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -1,0 +1,58 @@
+# Project Map
+
+**What this is:** Andrew Furusawa's personal portfolio at `andrewfurusawa.dev`, deployed on Vercel. One codebase, two **presentations** of the same substance: the public modern portfolio at `/`, and a soft-secret 90s experiment at `/90s`. There is no CMS, no database, and no API — content is TypeScript modules under `app/config/`.
+
+**Stack:** Next.js 15 App Router, React 19, TypeScript 5, Tailwind v4 (PostCSS), react-icons, Vitest, Vercel Speed Insights.
+
+_Last updated: 2026-08-06. Update this map when architecture or ownership changes in a way that matters._
+
+This file is orientation: how the system is shaped and why. For *where a file lives*, use [`agent-context-map.md`](agent-context-map.md). For *what is being worked on now*, use [`../PLAN.md`](../PLAN.md). For *what a word means*, use [`../CONTEXT.md`](../CONTEXT.md).
+
+## Routes and ownership
+
+| Route | Owned by | Public? |
+|-------|----------|---------|
+| `/` | `app/(portfolio)/` + `app/components/` | Yes — indexed, in the sitemap |
+| `/90s` | `app/90s/` alone | Soft secret — crawl-allowed, `X-Robots-Tag` `noindex, nofollow`, not in the sitemap |
+| `/prototype/90s-shell` | `app/prototype/` | Throwaway; kept for reference, not a product surface |
+
+The **route-group seam is the whole architecture**. `app/layout.tsx` is deliberately slim — `<html>`, fonts, global CSS, Speed Insights, and metadata, nothing visual. Portfolio chrome (background animation, theme toggle, page padding) lives in the `(portfolio)` group so it cannot leak onto `/90s`; the experiment's chrome lives entirely in `app/90s/nineties.module.css` behind a single `.experiment` class.
+
+**Anything added to the root layout appears on both presentations.** That is almost never what you want.
+
+## Data contracts
+
+Both presentations read the same data and share none of their chrome.
+
+| Contract | Shape | Consumed by |
+|----------|-------|-------------|
+| `Skill` (`app/config/skills.ts`) | `{ slug, name, icon, category }` | `/` skills section, `/90s` directory |
+| `ProfileLink` (`app/config/profileLinks.ts`) | `{ href, ariaLabel, label, Icon, openInNewTab, heroClassName? }` | `/` hero + contact, `/90s` contact |
+| Site identity (`app/config/site.ts`) | `SITE_URL`, `SITE_NAME`, `SITE_TITLE`, `SITE_DESCRIPTION`, `absoluteUrl()` | root metadata, `robots.ts`, `sitemap.ts` |
+| `pathHeaders` (`app/config/securityHeaders.ts`) | security tuples on `/:path*`; `X-Robots-Tag` on `/90s` and `/90s/:path*` | `next.config.ts` |
+
+`app/90s/` imports *data* from `app/config/` and *nothing* from `app/components/`. Share substance, never chrome — if a change makes the experiment import a portfolio component, the change is wrong.
+
+`slug` is authored, never derived — `/90s/skills/<slug>` must survive a display-name change. `category` is a closed union (Frontend · Mobile · Backend · Tooling · Design) in `CATEGORY_ORDER`; `/` ignores it. Homepage anchors are `skill-${slug}`. See [Prefactor the shared skills catalogue with authored slugs and categories](https://github.com/afurusawa/andrewfurusawa/issues/52).
+
+**Decided, not yet built:** v2 hub chrome pack is one tape under-construction graphic plus three 88×31 badges; the starfield stays CSS; CSS stand-ins must not ship. See [Define hi-fi chrome inventory and assets for /90s v2](https://github.com/afurusawa/andrewfurusawa/issues/41).
+
+## Conventions
+
+- **Tests are colocated `*.test.ts` next to the module.** Vitest runs in a `node` environment and only collects `app/**/*.test.ts` (`vitest.config.mts`). There is no DOM or component testing — which is *why* logic belongs in `app/lib/` and content in `app/config/`, where it is reachable.
+- **`npm test` runs the suite; `npm run dev` uses Turbopack.** A plugin Turbopack can't take is a real constraint, not a detail.
+- **Server components by default.** Only four client components exist (`ThemeToggle`, `SkillTile`, `SkillsFilter`, `SkillsFilterContext`) — interactive islands, deliberately budgeted. A fifth `"use client"` needs a reason.
+- **Theming is a `.dark` class on `<html>`** driving CSS variables in `app/globals.css`, toggled client-side from `localStorage`. `/90s` opts out of all of it.
+- **Performance is budgeted:** mobile p75 LCP ≤ 2.5 s, INP ≤ 200 ms, CLS ≤ 0.1; ≤ 500 KB initial transfer, ≤ 150 KB initial JS. A new dependency or font is a budget decision.
+- **WCAG 2.2 AA on every route**, kitsch included. Motion respects `prefers-reduced-motion`.
+
+## Design authority
+
+v1's [`design/90s-experiment-spec.md`](design/90s-experiment-spec.md) is **historical**. It remains binding for the *shipped* `/90s` until v2 is implemented. v2 taste and scope live in a GitHub **spec** issue produced from [Wayfinder: /90s hi-fi kitsch and skill-note content spec](https://github.com/afurusawa/andrewfurusawa/issues/35) — not in a new `docs/design/` file. Before that issue exists, the map and its closed tickets are the record. After v2 ships, the code wins.
+
+`adr/` holds architecture decision records. It does not exist yet — nothing has cleared the hard-to-reverse, surprising, real-trade-off bar.
+
+## Known sharp edges
+
+- **`/90s` is a soft secret by header, not by `robots.txt`.** `robots.txt` does not name `/90s`. `X-Robots-Tag: noindex, nofollow` is sent on `/90s` and `/90s/:path*`. The experiment layout still exports `robots: { index: false, follow: false }`. See [Switch /90s to crawl-allowed de-indexing](https://github.com/afurusawa/andrewfurusawa/issues/53).
+- **`README.md` is untouched `create-next-app` boilerplate** describing fonts this project doesn't use. Trust this map over it.

--- a/docs/agent-context-map.md
+++ b/docs/agent-context-map.md
@@ -1,0 +1,91 @@
+# Agent context map
+
+Path inventory. **Read the one section you need, not the whole file.** For why the system is shaped this way, read [`MAP.md`](MAP.md) instead.
+
+_Last updated: 2026-08-06._
+
+## Routes and layouts
+
+| Path | Holds |
+|------|-------|
+| `app/layout.tsx` | Root layout — `<html>`, font variables, `globals.css`, Speed Insights, site metadata. Deliberately non-visual. |
+| `app/(portfolio)/layout.tsx` | Modern presentation chrome: background animation, theme toggle, page padding. |
+| `app/(portfolio)/page.tsx` | The public homepage `/`. |
+| `app/90s/layout.tsx` | Experiment shell — wraps children in the `.experiment` class, exports its metadata. |
+| `app/90s/page.tsx` | The `/90s` page. |
+| `app/90s/metadata.ts` | Experiment layout unfurl + `noindex`; hub canonical lives on the page. |
+| `app/90s/nineties.module.css` | All experiment chrome. Nothing else styles `/90s`. |
+| `app/prototype/90s-shell/` | Throwaway shell variants A–D behind `?variant=`. Reference only. |
+
+## Content and configuration
+
+Everything here is data, not markup. New content belongs in this directory, never inlined in a component.
+
+| Path | Holds |
+|------|-------|
+| `app/config/skills.ts` | The skills catalogue — `Skill = { slug, name, icon, category }`, shared by both presentations. |
+| `app/config/profileLinks.ts` | Social and contact links — `ProfileLink`, plus hero-specific styling. |
+| `app/config/site.ts` | `SITE_URL`, `SITE_NAME`, `SITE_TITLE`, `SITE_DESCRIPTION`, `absoluteUrl()`. |
+| `app/config/fonts.ts` | All four Google fonts, loaded once at the root as CSS variables. |
+| `app/config/securityHeaders.ts` | Response headers, consumed by `next.config.ts`. |
+
+## Logic
+
+Pure functions, no React, no side effects — this is what the node-environment test runner can reach.
+
+| Path | Holds |
+|------|-------|
+| `app/lib/filterSkills.ts` | Skills filtering for the homepage filter UI. |
+
+## Components (modern presentation only)
+
+Server components unless marked. `app/90s/` must not import from here.
+
+| Path | Client? |
+|------|---------|
+| `app/components/SkillsSection.tsx` | server |
+| `app/components/ExperienceSection.tsx` | server |
+| `app/components/ContactSection.tsx` | server |
+| `app/components/Footer.tsx` | server |
+| `app/components/BackgroundAnimation.tsx` | server |
+| `app/components/ThemeToggle.tsx` | **client** |
+| `app/components/SkillTile.tsx` | **client** |
+| `app/components/SkillsFilter.tsx` | **client** |
+| `app/components/SkillsFilterContext.tsx` | **client** |
+
+## Discoverability and build config
+
+| Path | Holds |
+|------|-------|
+| `app/robots.ts` | Crawler rules, sitemap and host declarations. Tested. |
+| `app/sitemap.ts` | Sitemap entries — `/` only. Tested. |
+| `next.config.ts` | Applies `pathHeaders`: security on `/:path*`, `X-Robots-Tag` on `/90s` and `/90s/:path*`. |
+| `vitest.config.mts` | node environment, collects `app/**/*.test.ts` only. |
+| `postcss.config.mjs`, `app/globals.css` | Tailwind v4 entry and the light/dark CSS-variable themes. |
+
+## Docs
+
+| Path | Holds |
+|------|-------|
+| `docs/MAP.md` | Orientation: architecture, route ownership, data contracts, conventions. |
+| `docs/agent-context-map.md` | This file. |
+| `CONTEXT.md` (root) | Domain glossary. Search its headings; don't load it whole. |
+| `PLAN.md` (root) | Objective, active slice, backlog, completed ledger. |
+| `AGENTS.md` (root) | Always-on rules. |
+| `docs/design/90s-experiment-spec.md` | v1 `/90s` spec, historical. Do not treat as v2 authority. |
+| `docs/agents/issue-tracker.md` | How issues, PRDs, and wayfinder maps are expressed on GitHub here. |
+| `docs/agents/triage-labels.md` | The five canonical triage labels. |
+| `docs/agents/domain.md` | How skills should consume `CONTEXT.md` and `docs/adr/`. |
+| `docs/adr/` | Architecture decision records. Does not exist yet. |
+
+## Do not load
+
+Point-in-time evidence and scratch output, archived on purpose. Open only if sent there by name.
+
+| Path | Why |
+|------|-----|
+| `docs/research/` | Dated research notes; findings that mattered are already in specs and decisions. |
+| `.lighthouse-#14/` | Scratch output from an old ticket run. |
+| `*.report.html` (repo root) | 2025 Lighthouse reports for the dead `.com` domain. |
+| `README.md` | Unmodified `create-next-app` boilerplate; inaccurate about this project. |
+| `.agents/skills/`, `.claude/skills/` | Vendored agent skill definitions, not project code. |


### PR DESCRIPTION
## Summary

Rolls up the remaining work on this branch on top of the `/90s` voice law:

- **Skills catalogue prefactor** — authored slugs and categories in `app/config/skills.ts`, with `skillDomId` retired in favour of the authored slug. Consumers (`SkillTile`, `SkillsSection`) updated.
- **`/90s` de-indexing** — switched to crawl-allowed de-indexing: `X-Robots-Tag: noindex, nofollow` via `securityHeaders`, the disallow rule dropped from `robots.ts`, and hub canonical/unfurl metadata moved onto `app/90s/metadata.ts`.
- **Orientation docs** — `CONTEXT.md` (ubiquitous language), `PLAN.md` (active slice + backlog snapshot), `docs/MAP.md` (architecture and route ownership), and `docs/agent-context-map.md` (path inventory).

## Notes

Test coverage moved with the code: new `app/90s/metadata.test.ts`, `app/config/securityHeaders.test.ts`, and `app/(portfolio)/inboundLinks.test.ts` (guarding the soft-secret rule that nothing on `/` links to `/90s`); `app/lib/skillDomId.test.ts` and `app/90s/layout.test.ts` removed alongside the code they covered.

The docs commit is documentation only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)