### PR TITLE
Add featured work section to the /90s hub

### DIFF
--- a/app/90s/copy.test.ts
+++ b/app/90s/copy.test.ts
@@ -4,6 +4,7 @@ import {
   CONTACT_LEAD_IN,
   EYEBROW,
   HUB_HEADING,
+  WORK_HELPER,
 } from "./copy";
 
 describe("/90s voice-law copy", () => {
@@ -18,6 +19,12 @@ describe("/90s voice-law copy", () => {
       "I'm a front-end developer, twelve years in, most of it taking web applications from discovery through release and then living with them afterwards. The part I like is the middle — turning a vague requirement into something people can actually click.",
       "The skills below aren't a checklist. Where I have something worth saying about a tool, it's a link: where I used it, why it fit, and what it taught me.",
     ]);
+  });
+
+  it("explains link-free work with the locked helper", () => {
+    expect(WORK_HELPER).toBe(
+      "Client work, so there's nothing public to link. The stacks below are.",
+    );
   });
 
   it("keeps the contact lead-in as plain words", () => {

--- a/app/90s/copy.ts
+++ b/app/90s/copy.ts
@@ -8,10 +8,14 @@ export const ABOUT_PARAGRAPHS = [
   "The skills below aren't a checklist. Where I have something worth saying about a tool, it's a link: where I used it, why it fit, and what it taught me.",
 ] as const;
 
+export const WORK_HELPER =
+  "Client work, so there's nothing public to link. The stacks below are.";
+
 export const CONTACT_LEAD_IN = "Email is best:";
 
 export const PANE_GARNISH = {
   about: "Welcome, traveler",
+  work: "Now shipping",
   skills: "Signal acquired",
   contact: "Open channels",
 } as const;

--- a/app/90s/nineties.module.css
+++ b/app/90s/nineties.module.css
@@ -198,13 +198,14 @@ p.eyebrow {
   text-shadow: none;
 }
 
-.navigationLink:nth-child(2) {
+.navigationLink:nth-child(3) {
   border-color: #9cf #036 #036 #9cf;
   background: linear-gradient(180deg, #123040, #0a1a22);
   color: var(--cyan);
 }
 
-.navigationLink:nth-child(3),
+.navigationLink:nth-child(2),
+.navigationLink:nth-child(4),
 .contactLinks .profileLink {
   border-color: #f9f #603 #603 #f9f;
   background: linear-gradient(180deg, #301230, #1a0a1a);
@@ -292,6 +293,10 @@ p.eyebrow {
     inset 0 0 0 1px rgb(0 255 255 / 12%);
 }
 
+.workPane {
+  border-color: var(--magenta);
+}
+
 .skillsPane {
   border-color: var(--cyan);
 }
@@ -337,6 +342,56 @@ p.eyebrow {
 
 .paneBody p:not(.microcopy):last-of-type {
   margin-bottom: 0;
+}
+
+/* Featured work: a light strip of cards, no images and no project links. */
+.workList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 0.85rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.workItem {
+  padding: 0.6rem 0.7rem;
+  border: 2px solid;
+  border-color: #f9f #603 #603 #f9f;
+  background: rgb(26 0 26 / 45%);
+}
+
+.workTitle {
+  margin: 0 0 0.25rem;
+  color: var(--cyan);
+  font-family: var(--font-display);
+  font-size: max(1.125rem, var(--text-floor));
+  font-weight: 400;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.paneBody p.workMeta {
+  margin-bottom: 0.4rem;
+  color: var(--muted);
+  font-size: max(0.875rem, var(--text-floor));
+}
+
+.stackTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0.6rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.stackTag {
+  padding: 0.15rem 0.45rem;
+  border: 1px solid var(--green);
+  background: #001a0a;
+  color: var(--green);
+  font-size: max(0.875rem, var(--text-floor));
 }
 
 .socialLinks,

--- a/app/90s/page.tsx
+++ b/app/90s/page.tsx
@@ -3,6 +3,7 @@ import {
   socialProfileLinks,
   type ProfileLink,
 } from "../config/profileLinks";
+import { featuredWork } from "../config/featuredWork";
 import { skills } from "../config/skills";
 import {
   ABOUT_PARAGRAPHS,
@@ -12,6 +13,7 @@ import {
   HUB_HEADING,
   PANE_GARNISH,
   ROLE,
+  WORK_HELPER,
 } from "./copy";
 import { ninetiesHubMetadata } from "./metadata";
 import styles from "./nineties.module.css";
@@ -20,9 +22,13 @@ export const metadata = ninetiesHubMetadata;
 
 const navigationItems = [
   { href: "#about", label: "About" },
+  { href: "#work", label: "Work" },
   { href: "#skills", label: "Skills" },
   { href: "#contact", label: "Contact" },
 ] as const;
+
+// Stack entries are catalogue slugs; the catalogue owns how a skill is named.
+const skillNamesBySlug = new Map(skills.map((skill) => [skill.slug, skill.name]));
 
 const cosmeticHitCount = "001337";
 
@@ -134,6 +140,43 @@ export default function NinetiesExperiment() {
               className={styles.socialLinks}
               ariaLabel="Andrew's social profiles"
             />
+          </div>
+        </section>
+
+        <section className={`${styles.pane} ${styles.workPane}`} id="work" aria-labelledby="work-heading">
+          <div className={styles.paneBar}>
+            <h2 id="work-heading">
+              <span aria-hidden="true">:: </span>
+              Work
+              <span aria-hidden="true"> ::</span>
+            </h2>
+            <span aria-hidden="true">{PANE_GARNISH.work}</span>
+          </div>
+          <div className={styles.paneBody}>
+            <p className={styles.microcopy}>{WORK_HELPER}</p>
+            <ul className={styles.workList}>
+              {featuredWork.map((project) => (
+                <li className={styles.workItem} key={project.slug}>
+                  <h3 className={styles.workTitle}>{project.title}</h3>
+                  <p className={styles.workMeta}>
+                    <span>{project.role}</span>
+                    <span aria-hidden="true"> · </span>
+                    <span>{project.period}</span>
+                  </p>
+                  <p>{project.blurb}</p>
+                  <ul
+                    className={styles.stackTags}
+                    aria-label={`${project.title} stack`}
+                  >
+                    {project.stack.map((slug) => (
+                      <li className={styles.stackTag} key={slug}>
+                        {skillNamesBySlug.get(slug) ?? slug}
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              ))}
+            </ul>
           </div>
         </section>
 

--- a/app/config/featuredWork.test.ts
+++ b/app/config/featuredWork.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { featuredWork } from "./featuredWork";
+import { skills } from "./skills";
+
+describe("featuredWork config", () => {
+  it("shows the curated projects in order", () => {
+    expect(
+      featuredWork.map((project) => ({
+        title: project.title,
+        role: project.role,
+        period: project.period,
+      })),
+    ).toEqual([
+      {
+        title: "MilkTracker",
+        role: "Lead front-end developer, Angel Eye Health",
+        period: "2020–2024",
+      },
+      {
+        title: "Blossom / GroConnect",
+        role: "Lead mobile app developer, Scotts Miracle-Gro",
+        period: "2017–2020",
+      },
+      {
+        title: "AI education platform",
+        role: "Lead developer, freelance",
+        period: "2025–present",
+      },
+    ]);
+  });
+
+  it("caps featured work at three without requiring a floor", () => {
+    expect(featuredWork.length).toBeLessThanOrEqual(3);
+  });
+
+  it("tags every project with catalogue slugs", () => {
+    const catalogueSlugs = new Set(skills.map((skill) => skill.slug));
+
+    for (const project of featuredWork) {
+      expect(project.stack.length).toBeGreaterThan(0);
+
+      for (const slug of project.stack) {
+        expect(catalogueSlugs).toContain(slug);
+      }
+    }
+  });
+
+  it("gives every project a blurb and a unique slug", () => {
+    for (const project of featuredWork) {
+      expect(project.slug.length).toBeGreaterThan(0);
+      expect(project.blurb.length).toBeGreaterThan(0);
+    }
+
+    expect(new Set(featuredWork.map((project) => project.slug)).size).toBe(
+      featuredWork.length,
+    );
+  });
+
+  it("ships every project link-free", () => {
+    for (const project of featuredWork) {
+      expect(project.links ?? []).toEqual([]);
+    }
+  });
+});

--- a/app/config/featuredWork.ts
+++ b/app/config/featuredWork.ts
@@ -1,0 +1,46 @@
+export type FeaturedProject = {
+  slug: string;
+  title: string;
+  blurb: string;
+  role: string;
+  period: string;
+  /** Catalogue slugs from `skills.ts`. */
+  stack: string[];
+  links?: { label: string; href: string }[];
+};
+
+/**
+ * Featured work, shared by every presentation. Membership in this array is
+ * featuring — there is no `featured` flag — and the order is hand-curated.
+ * Capped at three; there is no floor. All three are client work with nothing
+ * public to link, so none of them carry `links`.
+ */
+export const featuredWork: readonly FeaturedProject[] = [
+  {
+    slug: "milktracker",
+    title: "MilkTracker",
+    blurb:
+      "Rebuilt a neonatal milk-tracking app as one Angular and Ionic codebase across web, iOS and Android, replacing a legacy Objective-C app in 10 hospitals nationwide.",
+    role: "Lead front-end developer, Angel Eye Health",
+    period: "2020–2024",
+    stack: ["angular", "ionic", "typescript", "rxjs", "jasmine"],
+  },
+  {
+    slug: "blossom-groconnect",
+    title: "Blossom / GroConnect",
+    blurb:
+      "Inherited a smart-irrigation controller app at acquisition, cut load time by over 70% for 20,000+ users, then unified the device family under one app.",
+    role: "Lead mobile app developer, Scotts Miracle-Gro",
+    period: "2017–2020",
+    stack: ["ionic", "cordova", "angular", "typescript", "bitrise"],
+  },
+  {
+    slug: "ai-education-platform",
+    title: "AI education platform",
+    blurb:
+      "Ground-up Next.js build of an AI-integrated education platform, consulting from requirements and prioritisation through architecture and delivery.",
+    role: "Lead developer, freelance",
+    period: "2025–present",
+    stack: ["nextjs", "react", "typescript", "tailwindcss"],
+  },
+];

--- a/docs/agent-context-map.md
+++ b/docs/agent-context-map.md
@@ -26,6 +26,7 @@ Everything here is data, not markup. New content belongs in this directory, neve
 | Path | Holds |
 |------|-------|
 | `app/config/skills.ts` | The skills catalogue — `Skill = { slug, name, icon, category }`, shared by both presentations. |
+| `app/config/featuredWork.ts` | Featured work — `FeaturedProject`, hand-curated and capped at three. Membership is featuring; `stack` entries are catalogue slugs. |
 | `app/config/profileLinks.ts` | Social and contact links — `ProfileLink`, plus hero-specific styling. |
 | `app/config/site.ts` | `SITE_URL`, `SITE_NAME`, `SITE_TITLE`, `SITE_DESCRIPTION`, `absoluteUrl()`. |
 | `app/config/fonts.ts` | All four Google fonts, loaded once at the root as CSS variables. |


### PR DESCRIPTION
## Summary

- Add a curated, link-free featured work section to `/90s`.
- Display project roles, periods, blurbs, and catalogue-backed stack tags.
- Add configuration tests and document the new work catalogue path.

## Testing

- Added Vitest coverage for project ordering, limits, catalogue slugs, uniqueness, content, and link-free entries.
- Added copy test coverage for the work helper text.
- Not run.