### PR TITLE
Replace the /90s skills table with the category tile directory

### DIFF
--- a/app/90s/copy.test.ts
+++ b/app/90s/copy.test.ts
@@ -4,6 +4,7 @@ import {
   CONTACT_LEAD_IN,
   EYEBROW,
   HUB_HEADING,
+  SKILLS_HELPER,
   WORK_HELPER,
 } from "./copy";
 
@@ -24,6 +25,12 @@ describe("/90s voice-law copy", () => {
   it("explains link-free work with the locked helper", () => {
     expect(WORK_HELPER).toBe(
       "Client work, so there's nothing public to link. The stacks below are.",
+    );
+  });
+
+  it("states the publish-set split with the locked skills helper", () => {
+    expect(SKILLS_HELPER).toBe(
+      "Skills with a note are links. The rest are here for the record.",
     );
   });
 

--- a/app/90s/copy.ts
+++ b/app/90s/copy.ts
@@ -11,6 +11,9 @@ export const ABOUT_PARAGRAPHS = [
 export const WORK_HELPER =
   "Client work, so there's nothing public to link. The stacks below are.";
 
+export const SKILLS_HELPER =
+  "Skills with a note are links. The rest are here for the record.";
+
 export const CONTACT_LEAD_IN = "Email is best:";
 
 export const PANE_GARNISH = {

--- a/app/90s/nineties.module.css
+++ b/app/90s/nineties.module.css
@@ -144,47 +144,70 @@ p.eyebrow {
   color: var(--green);
 }
 
-.tableScroll {
-  overflow-x: auto;
+/* Skills directory: a wall of icon tiles grouped by category. */
+.skillGroup {
+  margin-top: 1.25rem;
 }
 
-.skillsTable {
-  width: 100%;
-  border-collapse: collapse;
-  color: var(--green);
-  font: inherit;
-}
-
-.skillsTable caption {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.skillsTable th,
-.skillsTable td {
-  padding: 0.35rem 0.5rem;
-  border: 1px solid var(--green);
-  text-align: left;
-}
-
-.skillsTable th {
+.skillGroupHeading {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 0 0 0.6rem;
+  padding-bottom: 0.2rem;
+  border-bottom: 1px solid rgb(255 0 255 / 40%);
   color: var(--cyan);
-  background: rgb(0 255 102 / 12%);
+  /* Short, uppercase, scanned rather than read — the display face earns it
+     here, sized up because VT323 renders small for its point size. */
+  font-family: var(--font-display);
+  font-size: max(1.35rem, var(--text-floor));
+  font-weight: 400;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-.skillsTable td:first-child {
-  white-space: nowrap;
+/* The count riding along in the heading is text, so it stays on the
+   reading face at the floor size and out of the glow. */
+.skillGroupCount {
+  color: var(--muted);
+  font-family: var(--font-reading);
+  font-size: max(0.875rem, var(--text-floor));
+  letter-spacing: normal;
+  text-transform: none;
+  text-shadow: none;
 }
 
-.skillsTable svg {
-  vertical-align: -0.12em;
+.skillWall {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(8.5rem, 1fr));
+  gap: 0.6rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* Listed-only tile: green bevel, non-interactive, dimmed but still readable. */
+.skillTile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.6rem 0.35rem;
+  border: 3px solid;
+  border-color: #8cffb8 #003d1f #003d1f #8cffb8;
+  background: linear-gradient(180deg, #12301f, #0a1a12);
+  color: var(--green);
+  font-size: max(0.9375rem, var(--text-floor));
+  line-height: 1.2;
+  text-align: center;
+  text-shadow: none;
+  opacity: 0.85;
+}
+
+.skillTile svg {
+  width: 2.25rem;
+  height: 2.25rem;
 }
 
 .navigationLink {

--- a/app/90s/page.tsx
+++ b/app/90s/page.tsx
@@ -5,6 +5,7 @@ import {
 } from "../config/profileLinks";
 import { featuredWork } from "../config/featuredWork";
 import { skills } from "../config/skills";
+import { getSkillDirectory, groupCountLabel } from "../lib/skillDirectory";
 import {
   ABOUT_PARAGRAPHS,
   CONTACT_LEAD_IN,
@@ -13,6 +14,7 @@ import {
   HUB_HEADING,
   PANE_GARNISH,
   ROLE,
+  SKILLS_HELPER,
   WORK_HELPER,
 } from "./copy";
 import { ninetiesHubMetadata } from "./metadata";
@@ -29,6 +31,9 @@ const navigationItems = [
 
 // Stack entries are catalogue slugs; the catalogue owns how a skill is named.
 const skillNamesBySlug = new Map(skills.map((skill) => [skill.slug, skill.name]));
+
+// Grouped once at module scope: the directory is static build-time data.
+const skillDirectory = getSkillDirectory();
 
 const cosmeticHitCount = "001337";
 
@@ -190,31 +195,35 @@ export default function NinetiesExperiment() {
             <span aria-hidden="true">{PANE_GARNISH.skills}</span>
           </div>
           <div className={styles.paneBody}>
-            <div className={styles.tableScroll}>
-              <table className={styles.skillsTable}>
-                <caption>{HUB_HEADING}&apos;s skills catalogue</caption>
-                <thead>
-                  <tr>
-                    <th scope="col">#</th>
-                    <th scope="col">Skill</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {skills.map((skill, index) => {
-                    const Icon = skill.icon;
+            <p className={styles.microcopy}>{SKILLS_HELPER}</p>
+            {skillDirectory.map((group) => {
+              const headingId = `skills-${group.category.toLowerCase()}`;
 
-                    return (
-                      <tr key={skill.slug}>
-                        <td>{String(index + 1).padStart(2, "0")}</td>
-                        <td>
-                          <Icon aria-hidden="true" /> {skill.name}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
+              return (
+                <div className={styles.skillGroup} key={group.category}>
+                  <h3 className={styles.skillGroupHeading} id={headingId}>
+                    {group.category}
+                    <span className={styles.skillGroupCount}>
+                      {groupCountLabel(group)}
+                    </span>
+                  </h3>
+                  <ul className={styles.skillWall} aria-labelledby={headingId}>
+                    {group.skills.map((skill) => {
+                      const Icon = skill.icon;
+
+                      // Every tile is listed-only until the first note ships;
+                      // `hasNote` already carries the split in the data.
+                      return (
+                        <li className={styles.skillTile} key={skill.slug}>
+                          <Icon aria-hidden="true" />
+                          <span>{skill.name}</span>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              );
+            })}
           </div>
         </section>
 

--- a/app/lib/skillDirectory.test.ts
+++ b/app/lib/skillDirectory.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { CATEGORY_ORDER, skills } from "../config/skills";
+import {
+  buildSkillDirectory,
+  getSkillDirectory,
+  groupCountLabel,
+  skillNoteHref,
+} from "./skillDirectory";
+
+describe("skill directory", () => {
+  it("groups the catalogue in CATEGORY_ORDER", () => {
+    expect(getSkillDirectory().map((group) => group.category)).toEqual([
+      ...CATEGORY_ORDER,
+    ]);
+  });
+
+  it("keeps catalogue order within a group and loses no skill", () => {
+    const directory = getSkillDirectory();
+
+    expect(directory.flatMap((group) => group.skills.map((s) => s.slug))).toEqual(
+      [...CATEGORY_ORDER].flatMap((category) =>
+        skills.filter((s) => s.category === category).map((s) => s.slug),
+      ),
+    );
+    expect(directory.reduce((sum, group) => sum + group.total, 0)).toBe(
+      skills.length,
+    );
+  });
+
+  it("lists every skill without a note while the publish set is empty", () => {
+    const directory = getSkillDirectory();
+
+    expect(directory.every((group) => group.noted === 0)).toBe(true);
+    expect(
+      directory.every((group) => group.skills.every((s) => !s.hasNote)),
+    ).toBe(true);
+  });
+
+  it("marks note presence from the publish set it is given", () => {
+    const directory = buildSkillDirectory(skills, ["ionic"]);
+    const mobile = directory.find((group) => group.category === "Mobile");
+
+    expect(mobile?.noted).toBe(1);
+    expect(mobile?.skills.find((s) => s.slug === "ionic")?.hasNote).toBe(true);
+    expect(mobile?.skills.find((s) => s.slug === "cordova")?.hasNote).toBe(false);
+  });
+
+  it("drops a category with no skills rather than heading an empty group", () => {
+    const directory = buildSkillDirectory(
+      skills.filter((skill) => skill.category !== "Design"),
+      [],
+    );
+
+    expect(directory.map((group) => group.category)).not.toContain("Design");
+  });
+
+  it("counts a group as '<n> · <m> with notes'", () => {
+    const [frontend] = buildSkillDirectory(skills, ["react", "redux"]);
+
+    expect(groupCountLabel(frontend)).toBe("13 · 2 with notes");
+  });
+
+  it("points a note at its slug under the experiment", () => {
+    expect(skillNoteHref("ionic")).toBe("/90s/skills/ionic");
+  });
+});

--- a/app/lib/skillDirectory.ts
+++ b/app/lib/skillDirectory.ts
@@ -1,0 +1,66 @@
+import {
+  CATEGORY_ORDER,
+  skills,
+  type Skill,
+  type SkillCategory,
+} from "../config/skills";
+
+/** A catalogue skill plus whether a skill note has been published for it. */
+export type DirectorySkill = Skill & { hasNote: boolean };
+
+export type SkillDirectoryGroup = {
+  category: SkillCategory;
+  skills: readonly DirectorySkill[];
+  /** Skills in the group. */
+  total: number;
+  /** Of those, how many have a note. */
+  noted: number;
+};
+
+/**
+ * Slugs of the skills with a published note — the publish set. Empty until the
+ * first note ships, which is why every tile is listed-only today. When notes
+ * arrive this constant is replaced by the build-time join over the note files;
+ * nothing downstream re-derives note presence.
+ */
+const PUBLISHED_NOTE_SLUGS: readonly string[] = [];
+
+/**
+ * Group a catalogue into the directory shape: `CATEGORY_ORDER` outside,
+ * catalogue order preserved within a group, note presence resolved once.
+ * Empty categories are dropped rather than rendered as a bare heading.
+ */
+export function buildSkillDirectory(
+  catalogue: readonly Skill[],
+  noteSlugs: Iterable<string>,
+): readonly SkillDirectoryGroup[] {
+  const noted = new Set(noteSlugs);
+
+  return CATEGORY_ORDER.map((category) => {
+    const groupSkills = catalogue
+      .filter((skill) => skill.category === category)
+      .map((skill) => ({ ...skill, hasNote: noted.has(skill.slug) }));
+
+    return {
+      category,
+      skills: groupSkills,
+      total: groupSkills.length,
+      noted: groupSkills.filter((skill) => skill.hasNote).length,
+    };
+  }).filter((group) => group.total > 0);
+}
+
+/** The `/90s` skills directory: the shared catalogue in directory shape. */
+export function getSkillDirectory(): readonly SkillDirectoryGroup[] {
+  return buildSkillDirectory(skills, PUBLISHED_NOTE_SLUGS);
+}
+
+/** The heading count for a group: `<n> · <m> with notes`. */
+export function groupCountLabel(group: SkillDirectoryGroup): string {
+  return `${group.total} · ${group.noted} with notes`;
+}
+
+/** Where a skill's note lives. Only called for skills that have one. */
+export function skillNoteHref(slug: string): string {
+  return `/90s/skills/${slug}`;
+}

--- a/docs/agent-context-map.md
+++ b/docs/agent-context-map.md
@@ -39,6 +39,7 @@ Pure functions, no React, no side effects — this is what the node-environment 
 | Path | Holds |
 |------|-------|
 | `app/lib/filterSkills.ts` | Skills filtering for the homepage filter UI. |
+| `app/lib/skillDirectory.ts` | The `/90s` skills directory shape — catalogue grouped by category with note presence resolved. The publish set is owned here; nothing else re-derives it. |
 
 ## Components (modern presentation only)
 


### PR DESCRIPTION
Implements #57.

## What changed

- **`app/lib/skillDirectory.ts` (new)** — the directory shape: the shared catalogue grouped by `CATEGORY_ORDER`, catalogue order preserved inside a group, empty categories dropped, and note presence (`hasNote`, `noted`) resolved in one place. The publish set is an empty constant here today; the Ionic note ticket swaps it for the build-time join over note files without reshaping the consumer.
- **Skills pane on `/90s`** — the period table is gone. It is now a wall of icon tiles under `Frontend · Mobile · Backend · Tooling · Design`, each heading carrying `<n> · <m> with notes`, above the locked helper `Skills with a note are links. The rest are here for the record.`
- **Tile treatment** — every tile is listed-only: green bevel, no NOTE flag, non-interactive, `opacity: 0.85`. Labels are readable mono at 15px with the green glow stripped; category headings keep VT323 while the count riding along stays on the reading face at the 14px floor.
- Brand-mark icons render on the server — the prerendered `/90s` HTML contains all 35 tiles and their SVGs.
- The modern presentation''s skills UI is untouched.

## Verification

- `npm test` — 12 files, 39 tests pass, including 7 new directory tests (grouping order, no lost skills, the empty publish set, note marking from a given publish set, empty-category drop, count label, note href).
- `npx tsc --noEmit` and `npm run build` clean; `/90s` still prerenders static.
- Checked the built `/90s` HTML for the tile wall, the five group counts, the helper, and the absence of `<table>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)