### PR TITLE
Ship the Ionic skill note

### DIFF
--- a/app/90s/ExperimentNav.tsx
+++ b/app/90s/ExperimentNav.tsx
@@ -1,0 +1,51 @@
+import styles from "./nineties.module.css";
+
+const NAVIGATION_ITEMS = [
+  { id: "about", label: "About" },
+  { id: "work", label: "Work" },
+  { id: "skills", label: "Skills" },
+  { id: "contact", label: "Contact" },
+] as const;
+
+export type NavSection = (typeof NAVIGATION_ITEMS)[number]["id"];
+
+/**
+ * The experiment nav. The hub links to its own sections and carries the
+ * cosmetic counter; a note route links back to `/90s#…` so the reader is never
+ * a dead end, and marks the section it came from as current.
+ */
+export function ExperimentNav({
+  hrefBase = "",
+  current,
+  hitCount,
+}: {
+  /** `""` on the hub, `"/90s"` from a nested route. */
+  hrefBase?: string;
+  current?: NavSection;
+  hitCount?: string;
+}) {
+  return (
+    <nav className={styles.navigation} aria-label="Experiment sections">
+      {NAVIGATION_ITEMS.map((item) => (
+        <a
+          className={styles.navigationLink}
+          href={`${hrefBase}#${item.id}`}
+          key={item.id}
+          aria-current={item.id === current ? "page" : undefined}
+        >
+          {item.label}
+        </a>
+      ))}
+      {hitCount ? (
+        <div className={styles.hitCounter} aria-hidden="true">
+          <span>hits</span>
+          <span className={styles.hitDigits}>
+            {hitCount.split("").map((digit, index) => (
+              <span key={`${digit}-${index}`}>{digit}</span>
+            ))}
+          </span>
+        </div>
+      ) : null}
+    </nav>
+  );
+}

--- a/app/90s/NoteShell.tsx
+++ b/app/90s/NoteShell.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+import { EYEBROW, HUB_HEADING, NOTE_FOOTER } from "./copy";
+import { ExperimentNav } from "./ExperimentNav";
+import styles from "./nineties.module.css";
+
+/**
+ * The outer shell every note route shares — banner, hub nav, one bordered
+ * Document Window, footer. The experiment's 404 wears the same shell, so a
+ * missing note lands somewhere that still looks like the place it came from.
+ *
+ * `windowPath` is the fake DOS path on the window bar: garnish, aria-hidden.
+ */
+export function NoteShell({
+  windowPath,
+  children,
+}: {
+  windowPath: string;
+  children: ReactNode;
+}) {
+  return (
+    <main className={styles.stage}>
+      <header className={styles.banner}>
+        <p className={styles.eyebrow} aria-hidden="true">
+          {EYEBROW}
+        </p>
+        <p className={styles.noteSiteName}>{HUB_HEADING}</p>
+      </header>
+
+      <ExperimentNav hrefBase="/90s" current="skills" />
+
+      <article className={styles.noteWindow}>
+        <div className={styles.noteWindowBar} aria-hidden="true">
+          <span>{windowPath}</span>
+          <span>□ ×</span>
+        </div>
+        {children}
+      </article>
+
+      <footer className={styles.noteFooter} aria-hidden="true">
+        {NOTE_FOOTER}
+      </footer>
+    </main>
+  );
+}

--- a/app/90s/[...missing]/page.tsx
+++ b/app/90s/[...missing]/page.tsx
@@ -1,0 +1,13 @@
+import { notFound } from "next/navigation";
+
+/**
+ * Every unknown path under /90s, including an unknown note slug. The note route
+ * locks its params at build time (`dynamicParams = false`), and that rejection
+ * happens in the router, before any segment renders — so it would serve the
+ * global 404 rather than the experiment's. This catch-all renders instead, and
+ * calling notFound() here hands the request to app/90s/not-found.tsx with a 404
+ * status, keeping the experiment inside its own shell.
+ */
+export default function NinetiesMissing(): never {
+  notFound();
+}

--- a/app/90s/copy.test.ts
+++ b/app/90s/copy.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   ABOUT_PARAGRAPHS,
+  BACK_TO_DIRECTORY,
   CONTACT_LEAD_IN,
   EYEBROW,
   HUB_HEADING,
+  NOTE_MISSING_LEAD,
+  NOTE_MISSING_LINK,
   SKILLS_HELPER,
   WORK_HELPER,
 } from "./copy";
@@ -36,5 +39,15 @@ describe("/90s voice-law copy", () => {
 
   it("keeps the contact lead-in as plain words", () => {
     expect(CONTACT_LEAD_IN).toBe("Email is best:");
+  });
+
+  it("states the unknown note with the locked copy, the link last", () => {
+    expect(`${NOTE_MISSING_LEAD} ${NOTE_MISSING_LINK}`).toBe(
+      "That note doesn't exist. Back to the skills directory.",
+    );
+  });
+
+  it("names the escape after a note in plain words", () => {
+    expect(BACK_TO_DIRECTORY).toBe("Back to the skills directory");
   });
 });

--- a/app/90s/copy.ts
+++ b/app/90s/copy.ts
@@ -16,6 +16,16 @@ export const SKILLS_HELPER =
 
 export const CONTACT_LEAD_IN = "Email is best:";
 
+/** Link back to the directory — the breadcrumb's counterpart after a note. */
+export const BACK_TO_DIRECTORY = "Back to the skills directory";
+
+/**
+ * Unknown note slug. Two sentences: the first is plain text, the second is the
+ * real link, so the recovery is the link text rather than a bare "here".
+ */
+export const NOTE_MISSING_LEAD = "That note doesn't exist.";
+export const NOTE_MISSING_LINK = `${BACK_TO_DIRECTORY}.`;
+
 export const PANE_GARNISH = {
   about: "Welcome, traveler",
   work: "Now shipping",
@@ -25,3 +35,6 @@ export const PANE_GARNISH = {
 
 export const FOOTER =
   "Best viewed at 1024×768 · Built with notepad energy · No web ring membership";
+
+/** The note routes' own footer garnish, aria-hidden and kept to a short mark. */
+export const NOTE_FOOTER = "END OF FILE";

--- a/app/90s/metadata.test.ts
+++ b/app/90s/metadata.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { ninetiesHubMetadata, ninetiesMetadata } from "./metadata";
+import {
+  ninetiesHubMetadata,
+  ninetiesMetadata,
+  ninetiesNoteMetadata,
+} from "./metadata";
+import { getRenderedSkillNote } from "../lib/skillCatalogue";
 
 describe("/90s metadata", () => {
   it("discourages indexing from the experiment layout only", () => {
@@ -33,5 +38,41 @@ describe("/90s metadata", () => {
         "Nothing links here. You arrived by URL, which is the idea.",
       images: [],
     });
+  });
+});
+
+describe("/90s skill note metadata", () => {
+  it("gives a note its own self-referential canonical", () => {
+    expect(
+      ninetiesNoteMetadata({ slug: "ionic", name: "Ionic", summary: "S" })
+        .alternates?.canonical,
+    ).toBe("/90s/skills/ionic");
+  });
+
+  it("unfurls as '{name} · Andrew Furusawa' with the note's summary", async () => {
+    const note = await getRenderedSkillNote("ionic");
+    const metadata = ninetiesNoteMetadata(note!);
+
+    expect(metadata.title).toBe("Ionic · Andrew Furusawa");
+    expect(metadata.description).toBe(note!.summary);
+    expect(metadata.openGraph).toEqual({
+      type: "website",
+      title: "Ionic · Andrew Furusawa",
+      description: note!.summary,
+      images: [],
+    });
+    expect(metadata.twitter).toEqual({
+      card: "summary",
+      title: "Ionic · Andrew Furusawa",
+      description: note!.summary,
+      images: [],
+    });
+  });
+
+  it("exports no robots key of its own, so the layout's noindex survives the merge", () => {
+    expect(
+      ninetiesNoteMetadata({ slug: "ionic", name: "Ionic", summary: "S" })
+        .robots,
+    ).toBeUndefined();
   });
 });

--- a/app/90s/metadata.ts
+++ b/app/90s/metadata.ts
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { RenderedSkillNote } from "../lib/skillCatalogue";
 
 const unfurlTitle = "Andrew Furusawa · Neon Cyber Basement";
 const unfurlDescription =
@@ -32,3 +33,35 @@ export const ninetiesHubMetadata: Metadata = {
     canonical: "/90s",
   },
 };
+
+/**
+ * Skill-note metadata: its own self-referential canonical and an unfurl built
+ * from the catalogue name plus the note's summary. No `robots` key — metadata
+ * merges shallowly, so one here would drop the layout's `noindex` and leave the
+ * response header carrying the policy alone.
+ */
+export function ninetiesNoteMetadata(
+  note: Pick<RenderedSkillNote, "slug" | "name" | "summary">,
+): Metadata {
+  const title = `${note.name} · Andrew Furusawa`;
+
+  return {
+    title,
+    description: note.summary,
+    alternates: {
+      canonical: `/90s/skills/${note.slug}`,
+    },
+    openGraph: {
+      type: "website",
+      title,
+      description: note.summary,
+      images: [],
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description: note.summary,
+      images: [],
+    },
+  };
+}

--- a/app/90s/nineties.module.css
+++ b/app/90s/nineties.module.css
@@ -187,8 +187,13 @@ p.eyebrow {
   list-style: none;
 }
 
+.skillWall > li {
+  display: flex;
+}
+
 /* Listed-only tile: green bevel, non-interactive, dimmed but still readable. */
 .skillTile {
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -208,6 +213,34 @@ p.eyebrow {
 .skillTile svg {
   width: 2.25rem;
   height: 2.25rem;
+}
+
+/* Noted tile: magenta bevel, cyan label, and the tile itself is the link. */
+a.skillTileNoted {
+  border-color: #f9f #603 #603 #f9f;
+  background: linear-gradient(180deg, #301230, #1a0a1a);
+  color: var(--cyan);
+  text-decoration: none;
+  opacity: 1;
+}
+
+a.skillTileNoted:hover {
+  color: var(--magenta);
+}
+
+.skillTileFlag {
+  color: var(--magenta);
+  font-size: max(0.8125rem, var(--text-floor));
+  letter-spacing: 0.08em;
+}
+
+.stackTagLink {
+  color: var(--green);
+  text-underline-offset: 0.15em;
+}
+
+.stackTagLink:hover {
+  color: var(--cyan);
 }
 
 .navigationLink {
@@ -235,13 +268,23 @@ p.eyebrow {
   color: var(--magenta);
 }
 
+.navigationLink[aria-current="page"] {
+  border-color: #603 #f9f #f9f #603;
+  background: #250a28;
+  color: var(--cyan);
+}
+
 .navigationLink:hover,
 .profileLink:hover {
   color: var(--magenta);
 }
 
 .navigationLink:focus-visible,
-.profileLink:focus-visible {
+.profileLink:focus-visible,
+a.skillTileNoted:focus-visible,
+.stackTagLink:focus-visible,
+.noteBreadcrumb a:focus-visible,
+.noteBody a:focus-visible {
   outline: 3px solid var(--cyan);
   outline-offset: 3px;
   box-shadow: 0 0 0 5px var(--purple);
@@ -445,6 +488,144 @@ p.eyebrow {
   color: var(--cyan);
 }
 
+/* Skill note: one bordered document window on the same stage. */
+.noteSiteName {
+  margin: 0;
+  color: var(--cyan);
+  font-family: Impact, Haettenschweiler, "Arial Narrow Bold", sans-serif;
+  font-size: clamp(1.5rem, 3.5vw, 2.25rem);
+  letter-spacing: 0.08em;
+  line-height: 1.1;
+  text-transform: uppercase;
+  text-shadow:
+    0 0 10px rgb(0 255 255 / 65%),
+    2px 2px 0 var(--purple);
+}
+
+.noteWindow {
+  margin: 1rem;
+  border: 2px solid var(--cyan);
+  /* Opaque: the starfield never sits behind copy that is read. */
+  background: var(--panel);
+  box-shadow: inset 0 0 0 1px rgb(0 255 255 / 14%);
+}
+
+.noteWindowBar {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.3rem 0.6rem;
+  border-bottom: 1px solid var(--magenta);
+  background: linear-gradient(90deg, #1a0033, #003344);
+  color: var(--cyan);
+  font-size: max(0.9375rem, var(--text-floor));
+  letter-spacing: 0.06em;
+  pointer-events: none;
+  user-select: none;
+}
+
+.noteBreadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  padding: 0.75rem clamp(1rem, 5vw, 3rem) 0;
+  color: var(--muted);
+  font-size: max(0.875rem, var(--text-floor));
+}
+
+.noteBreadcrumb a {
+  color: var(--cyan);
+  text-underline-offset: 0.15em;
+}
+
+.noteBreadcrumb a:hover {
+  color: var(--magenta);
+}
+
+.noteHead {
+  padding: 1rem clamp(1rem, 5vw, 3rem) 1.4rem;
+  border-bottom: 1px solid rgb(0 255 102 / 35%);
+}
+
+/* The skill's own name, in mixed case — reading face, since VT323 is reserved
+   for short uppercase marks. */
+.noteHeading {
+  margin: 0;
+  color: var(--cyan);
+  font-family: var(--font-reading);
+  font-size: clamp(2rem, 6vw, 3rem);
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  line-height: 1.05;
+}
+
+.noteSummary {
+  max-width: 46rem;
+  margin: 0.9rem 0 0;
+  color: #e9fff0;
+  font-size: max(1.0625rem, var(--text-floor));
+  line-height: 1.55;
+  text-shadow: none;
+}
+
+.noteUpdated {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+  font-size: max(0.875rem, var(--text-floor));
+}
+
+/* The reading column: reading face, no glow, generous measure. */
+.noteBody {
+  max-width: 46rem;
+  margin: 0 auto;
+  padding: 1.6rem clamp(1rem, 5vw, 3rem) 2rem;
+  color: #e9fff0;
+  font-size: max(1rem, var(--text-floor));
+  line-height: 1.65;
+  text-shadow: none;
+}
+
+.noteBody h2 {
+  margin: 2.2rem 0 0.7rem;
+  color: var(--cyan);
+  font-family: var(--font-reading);
+  font-size: max(1.25rem, var(--text-floor));
+  letter-spacing: 0.04em;
+}
+
+.noteBody h2:first-child {
+  margin-top: 0;
+}
+
+.noteBody p {
+  margin: 0 0 1rem;
+}
+
+.noteBack {
+  display: inline-flex;
+  margin-top: 1.2rem;
+  color: var(--cyan);
+  font-weight: 700;
+  text-underline-offset: 0.15em;
+}
+
+.noteBack:hover,
+.noteBody a:hover {
+  color: var(--magenta);
+}
+
+.noteBody > p a {
+  color: var(--cyan);
+}
+
+.noteFooter {
+  padding: 0.65rem;
+  border-top: 1px solid var(--purple);
+  color: var(--muted);
+  font-size: max(0.875rem, var(--text-floor));
+  text-align: center;
+}
+
 .footer {
   padding: 0.75rem 1rem;
   border-top: 2px solid var(--purple);
@@ -471,8 +652,13 @@ p.eyebrow {
     justify-content: center;
   }
 
-  .paneBar {
+  .paneBar,
+  .noteWindowBar {
     flex-direction: column;
+  }
+
+  .noteWindow {
+    margin: 0.5rem;
   }
 }
 

--- a/app/90s/not-found.tsx
+++ b/app/90s/not-found.tsx
@@ -1,0 +1,20 @@
+import { NOTE_MISSING_LEAD, NOTE_MISSING_LINK } from "./copy";
+import { NoteShell } from "./NoteShell";
+import styles from "./nineties.module.css";
+
+/**
+ * The experiment's own 404, reached by an unknown note slug or any other stray
+ * path under /90s. Same shell as a note, plain pane inside, and the recovery is
+ * the last sentence rather than a bare "here".
+ */
+export default function NinetiesNotFound() {
+  return (
+    <NoteShell windowPath="C:\SKILLS\NOT.FOUND">
+      <div className={styles.noteBody}>
+        <p>
+          {NOTE_MISSING_LEAD} <a href="/90s#skills">{NOTE_MISSING_LINK}</a>
+        </p>
+      </div>
+    </NoteShell>
+  );
+}

--- a/app/90s/page.tsx
+++ b/app/90s/page.tsx
@@ -4,8 +4,13 @@ import {
   type ProfileLink,
 } from "../config/profileLinks";
 import { featuredWork } from "../config/featuredWork";
-import { skills } from "../config/skills";
-import { getSkillDirectory, groupCountLabel } from "../lib/skillDirectory";
+import { getSkillCatalogue } from "../lib/skillCatalogue";
+import {
+  getSkillDirectory,
+  groupCountLabel,
+  skillNoteHref,
+} from "../lib/skillDirectory";
+import { ExperimentNav } from "./ExperimentNav";
 import {
   ABOUT_PARAGRAPHS,
   CONTACT_LEAD_IN,
@@ -22,15 +27,11 @@ import styles from "./nineties.module.css";
 
 export const metadata = ninetiesHubMetadata;
 
-const navigationItems = [
-  { href: "#about", label: "About" },
-  { href: "#work", label: "Work" },
-  { href: "#skills", label: "Skills" },
-  { href: "#contact", label: "Contact" },
-] as const;
-
-// Stack entries are catalogue slugs; the catalogue owns how a skill is named.
-const skillNamesBySlug = new Map(skills.map((skill) => [skill.slug, skill.name]));
+// Stack entries are catalogue slugs; the join owns how a skill is named and
+// whether it has a note to link to.
+const catalogueBySlug = new Map(
+  getSkillCatalogue().map((skill) => [skill.slug, skill]),
+);
 
 // Grouped once at module scope: the directory is static build-time data.
 const skillDirectory = getSkillDirectory();
@@ -90,21 +91,7 @@ export default function NinetiesExperiment() {
         <p className={styles.tagline}>{ROLE}</p>
       </header>
 
-      <nav className={styles.navigation} aria-label="Experiment sections">
-        {navigationItems.map((item) => (
-          <a className={styles.navigationLink} href={item.href} key={item.href}>
-            {item.label}
-          </a>
-        ))}
-        <div className={styles.hitCounter} aria-hidden="true">
-          <span>hits</span>
-          <span className={styles.hitDigits}>
-            {cosmeticHitCount.split("").map((digit, index) => (
-              <span key={`${digit}-${index}`}>{digit}</span>
-            ))}
-          </span>
-        </div>
-      </nav>
+      <ExperimentNav hitCount={cosmeticHitCount} />
 
       <div className={styles.pack} aria-hidden="true">
         <img
@@ -173,11 +160,27 @@ export default function NinetiesExperiment() {
                     className={styles.stackTags}
                     aria-label={`${project.title} stack`}
                   >
-                    {project.stack.map((slug) => (
-                      <li className={styles.stackTag} key={slug}>
-                        {skillNamesBySlug.get(slug) ?? slug}
-                      </li>
-                    ))}
+                    {project.stack.map((slug) => {
+                      const skill = catalogueBySlug.get(slug);
+                      const label = skill?.name ?? slug;
+
+                      // A stack tag is a link only for the publish set, so the
+                      // strip can never point at a note that does not exist.
+                      return (
+                        <li className={styles.stackTag} key={slug}>
+                          {skill?.hasNote ? (
+                            <a
+                              className={styles.stackTagLink}
+                              href={skillNoteHref(slug)}
+                            >
+                              {label}
+                            </a>
+                          ) : (
+                            label
+                          )}
+                        </li>
+                      );
+                    })}
                   </ul>
                 </li>
               ))}
@@ -211,12 +214,30 @@ export default function NinetiesExperiment() {
                     {group.skills.map((skill) => {
                       const Icon = skill.icon;
 
-                      // Every tile is listed-only until the first note ships;
-                      // `hasNote` already carries the split in the data.
+                      // A noted tile is itself the link; a listed-only tile
+                      // stays plain text so it can never read as a dead link.
                       return (
-                        <li className={styles.skillTile} key={skill.slug}>
-                          <Icon aria-hidden="true" />
-                          <span>{skill.name}</span>
+                        <li key={skill.slug}>
+                          {skill.hasNote ? (
+                            <a
+                              className={`${styles.skillTile} ${styles.skillTileNoted}`}
+                              href={skillNoteHref(skill.slug)}
+                            >
+                              <Icon aria-hidden="true" />
+                              <span>{skill.name}</span>
+                              <span
+                                className={styles.skillTileFlag}
+                                aria-hidden="true"
+                              >
+                                NOTE ►
+                              </span>
+                            </a>
+                          ) : (
+                            <span className={styles.skillTile}>
+                              <Icon aria-hidden="true" />
+                              <span>{skill.name}</span>
+                            </span>
+                          )}
                         </li>
                       );
                     })}

--- a/app/90s/skills/[slug]/page.tsx
+++ b/app/90s/skills/[slug]/page.tsx
@@ -1,0 +1,70 @@
+import { notFound } from "next/navigation";
+import {
+  getPublishedNoteSlugs,
+  getRenderedSkillNote,
+} from "../../../lib/skillCatalogue";
+import { BACK_TO_DIRECTORY } from "../../copy";
+import { ninetiesNoteMetadata } from "../../metadata";
+import { NoteShell } from "../../NoteShell";
+import styles from "../../nineties.module.css";
+
+/** Only the publish set is routable; an unknown slug 404s instead of rendering. */
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return getPublishedNoteSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const note = await getRenderedSkillNote((await params).slug);
+
+  if (!note) {
+    return {};
+  }
+
+  return ninetiesNoteMetadata(note);
+}
+
+export default async function SkillNotePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const note = await getRenderedSkillNote((await params).slug);
+
+  if (!note) {
+    notFound();
+  }
+
+  return (
+    <NoteShell windowPath={`C:\\SKILLS\\${note.slug.toUpperCase()}.NOTE`}>
+      <nav className={styles.noteBreadcrumb} aria-label="Breadcrumb">
+        <a href="/90s">Home</a>
+        <span aria-hidden="true">/</span>
+        <a href="/90s#skills">Skills</a>
+        <span aria-hidden="true">/</span>
+        <span aria-current="page">{note.name}</span>
+      </nav>
+
+      <header className={styles.noteHead}>
+        <h1 className={styles.noteHeading}>{note.name}</h1>
+        <p className={styles.noteSummary}>{note.summary}</p>
+        {note.updated ? (
+          <p className={styles.noteUpdated}>Updated {note.updated}</p>
+        ) : null}
+      </header>
+
+      <div className={styles.noteBody}>
+        {/* Sanitized at build time by the note pipeline's rehype-sanitize pass. */}
+        <div dangerouslySetInnerHTML={{ __html: note.html }} />
+        <a className={styles.noteBack} href="/90s#skills">
+          {BACK_TO_DIRECTORY}
+        </a>
+      </div>
+    </NoteShell>
+  );
+}

--- a/app/lib/skillCatalogue.test.ts
+++ b/app/lib/skillCatalogue.test.ts
@@ -1,0 +1,144 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { skills } from "../config/skills";
+import {
+  getPublishedNoteSlugs,
+  getRenderedSkillNote,
+  getSkillCatalogue,
+  joinCatalogue,
+  parseSkillNote,
+  readSkillNotes,
+  renderNoteHtml,
+  type SkillNote,
+} from "./skillCatalogue";
+
+function note(slug: string, summary = `${slug} summary`): SkillNote {
+  return { slug, summary, body: "" };
+}
+
+describe("skill catalogue join", () => {
+  it("returns every catalogue skill in catalogue order", () => {
+    expect(getSkillCatalogue().map((skill) => skill.slug)).toEqual(
+      skills.map((skill) => skill.slug),
+    );
+  });
+
+  it("marks a skill with a matching note file and carries that note's summary", () => {
+    const joined = joinCatalogue(skills, [note("ionic", "Shared foundation.")]);
+    const ionic = joined.find((skill) => skill.slug === "ionic");
+
+    expect(ionic?.hasNote).toBe(true);
+    expect(ionic?.summary).toBe("Shared foundation.");
+  });
+
+  it("leaves a skill without a note listed-only rather than erroring", () => {
+    const joined = joinCatalogue(skills, [note("ionic")]);
+    const html = joined.find((skill) => skill.slug === "html");
+
+    expect(html?.hasNote).toBe(false);
+    expect(html?.summary).toBeUndefined();
+  });
+
+  it("throws on a note whose slug is not in the catalogue", () => {
+    expect(() => joinCatalogue(skills, [note("nextjs-typo")])).toThrow(
+      /nextjs-typo/,
+    );
+  });
+
+  it("publishes Ionic, the first shipping note", () => {
+    expect(getPublishedNoteSlugs()).toContain("ionic");
+    expect(
+      getSkillCatalogue().find((skill) => skill.slug === "ionic")?.summary,
+    ).toMatch(/^Ionic helped me deliver/);
+  });
+
+  it("keeps every note file on disk joinable to the catalogue", () => {
+    expect(() => joinCatalogue(skills, readSkillNotes())).not.toThrow();
+  });
+});
+
+describe("skill note parsing", () => {
+  it("requires a summary", () => {
+    expect(() => parseSkillNote("ionic", "## Where I used it\n")).toThrow(
+      /summary/,
+    );
+  });
+
+  it("reads the optional updated field only when present", () => {
+    expect(parseSkillNote("ionic", "---\nsummary: S\n---\n").updated).toBeUndefined();
+    expect(
+      parseSkillNote("ionic", "---\nsummary: S\nupdated: 2026-08-13\n---\n")
+        .updated,
+    ).toBe("2026-08-13");
+  });
+
+  it("takes the slug from the filename, not from frontmatter", () => {
+    const parsed = parseSkillNote("ionic", "---\nsummary: S\nskill: react\n---\nBody");
+
+    expect(parsed.slug).toBe("ionic");
+    expect(parsed.body.trim()).toBe("Body");
+  });
+});
+
+describe("skill note rendering", () => {
+  it("compiles standard Markdown to HTML", async () => {
+    const html = await renderNoteHtml(
+      "## Why it fit\n\nOne shared *model*, two stores.\n",
+    );
+
+    expect(html).toContain("<h2>Why it fit</h2>");
+    expect(html).toContain("<em>model</em>");
+  });
+
+  it("strips raw HTML rather than rendering it", async () => {
+    const html = await renderNoteHtml(
+      'Text <script>alert(1)</script> <span onclick="x()">more</span>\n',
+    );
+
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("onclick");
+  });
+
+  it("renders the Ionic note with its three sections and no updated line", async () => {
+    const rendered = await getRenderedSkillNote("ionic");
+
+    expect(rendered?.name).toBe("Ionic");
+    expect(rendered?.updated).toBeUndefined();
+    expect(rendered?.html).toContain("<h2>Where I used it</h2>");
+    expect(rendered?.html).toContain("<h2>Why it fit</h2>");
+    expect(rendered?.html).toContain("<h2>What it taught me</h2>");
+  });
+
+  it("has no note for a listed-only skill", async () => {
+    expect(await getRenderedSkillNote("html")).toBeUndefined();
+    expect(await getRenderedSkillNote("not-a-skill")).toBeUndefined();
+  });
+});
+
+describe("note pipeline dependencies", () => {
+  it("ships the six locked packages and no MDX, GFM, or raw-HTML plugin", () => {
+    const { dependencies } = JSON.parse(
+      readFileSync(join(process.cwd(), "package.json"), "utf8"),
+    ) as { dependencies: Record<string, string> };
+    const installed = Object.keys(dependencies);
+
+    expect(installed).toEqual(
+      expect.arrayContaining([
+        "gray-matter",
+        "unified",
+        "remark-parse",
+        "remark-rehype",
+        "rehype-sanitize",
+        "rehype-stringify",
+      ]),
+    );
+    expect(
+      installed.filter((name) =>
+        /^(@next\/mdx|@mdx-js\/|.*mdx|remark-gfm|rehype-raw|react-markdown)/.test(
+          name,
+        ),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/app/lib/skillCatalogue.ts
+++ b/app/lib/skillCatalogue.ts
@@ -1,0 +1,192 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import matter from "gray-matter";
+import rehypeSanitize from "rehype-sanitize";
+import rehypeStringify from "rehype-stringify";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import { unified } from "unified";
+import { skills, type Skill } from "../config/skills";
+
+/** Where skill notes live. The filename is the only skill association. */
+export const NOTES_DIRECTORY = join(process.cwd(), "content", "skills");
+
+/** A note file, parsed but not yet rendered. */
+export type SkillNote = {
+  /** Taken from the filename, never from frontmatter. */
+  slug: string;
+  summary: string;
+  updated?: string;
+  /** Markdown body with the frontmatter stripped. */
+  body: string;
+};
+
+/**
+ * A catalogue skill plus the publish-set answer. `summary` is the note's own
+ * teaser and is present exactly when `hasNote` is true.
+ */
+export type CatalogueSkill = Skill & {
+  hasNote: boolean;
+  summary?: string;
+};
+
+/** A note ready to render: catalogue identity plus sanitized HTML. */
+export type RenderedSkillNote = {
+  slug: string;
+  name: string;
+  summary: string;
+  updated?: string;
+  html: string;
+};
+
+function frontmatterString(value: unknown): string | undefined {
+  // YAML turns a bare date into a Date; keep the day, drop the clock.
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+
+  return typeof value === "string" && value.trim() !== ""
+    ? value.trim()
+    : undefined;
+}
+
+/**
+ * Parse one note file. `summary` is required — it is both the directory teaser
+ * and the note's meta description, so a note without one cannot ship.
+ */
+export function parseSkillNote(slug: string, source: string): SkillNote {
+  const { data, content } = matter(source);
+  const summary = frontmatterString(data.summary);
+
+  if (!summary) {
+    throw new Error(
+      `Skill note "${slug}" is missing a summary. Frontmatter requires summary.`,
+    );
+  }
+
+  return {
+    slug,
+    summary,
+    updated: frontmatterString(data.updated),
+    body: content,
+  };
+}
+
+/** Read every note file. An empty or absent directory is the normal case. */
+export function readSkillNotes(directory = NOTES_DIRECTORY): SkillNote[] {
+  if (!existsSync(directory)) {
+    return [];
+  }
+
+  return readdirSync(directory)
+    .filter((entry) => entry.endsWith(".md"))
+    .map((entry) =>
+      parseSkillNote(
+        entry.slice(0, -".md".length),
+        readFileSync(join(directory, entry), "utf8"),
+      ),
+    );
+}
+
+/**
+ * The join: catalogue skills augmented with note presence and summary.
+ *
+ * An orphan note — a file whose slug names no catalogue skill — throws here
+ * rather than shipping as a hub link to a 404. This runs at build time, so the
+ * throw gates `next build`.
+ */
+export function joinCatalogue(
+  catalogue: readonly Skill[],
+  notes: readonly SkillNote[],
+): readonly CatalogueSkill[] {
+  const bySlug = new Map(notes.map((note) => [note.slug, note]));
+  const known = new Set(catalogue.map((skill) => skill.slug));
+  const orphans = notes
+    .map((note) => note.slug)
+    .filter((slug) => !known.has(slug));
+
+  if (orphans.length > 0) {
+    throw new Error(
+      `Skill note${orphans.length > 1 ? "s" : ""} with no catalogue skill: ${orphans.join(", ")}. ` +
+        "Rename the file in content/skills/ to a catalogue slug, or add the skill.",
+    );
+  }
+
+  return catalogue.map((skill) => {
+    const note = bySlug.get(skill.slug);
+
+    return note
+      ? { ...skill, hasNote: true, summary: note.summary }
+      : { ...skill, hasNote: false };
+  });
+}
+
+let cachedNotes: readonly SkillNote[] | undefined;
+let cachedCatalogue: readonly CatalogueSkill[] | undefined;
+
+/** The notes on disk, read once per build rather than once per route. */
+function notes(): readonly SkillNote[] {
+  cachedNotes ??= readSkillNotes();
+
+  return cachedNotes;
+}
+
+/**
+ * The one join. Hub tiles, featured-work stack tags, and the note routes all
+ * read this shape; nothing else decides whether a skill has a note.
+ */
+export function getSkillCatalogue(): readonly CatalogueSkill[] {
+  cachedCatalogue ??= joinCatalogue(skills, notes());
+
+  return cachedCatalogue;
+}
+
+/** The publish set: slugs a note route may be generated for. */
+export function getPublishedNoteSlugs(): string[] {
+  return getSkillCatalogue()
+    .filter((skill) => skill.hasNote)
+    .map((skill) => skill.slug);
+}
+
+/**
+ * Compile note Markdown to sanitized HTML. Standard Markdown only — no GFM and
+ * no raw HTML, which the default sanitize schema strips on the way through.
+ */
+export async function renderNoteHtml(markdown: string): Promise<string> {
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkRehype)
+    .use(rehypeSanitize)
+    .use(rehypeStringify)
+    .process(markdown);
+
+  return String(file);
+}
+
+/**
+ * A note ready for its route, or `undefined` when the slug has no note. The
+ * name comes from the catalogue, never from the note file.
+ */
+export async function getRenderedSkillNote(
+  slug: string,
+): Promise<RenderedSkillNote | undefined> {
+  const skill = getSkillCatalogue().find((entry) => entry.slug === slug);
+
+  if (!skill?.hasNote) {
+    return undefined;
+  }
+
+  const note = notes().find((entry) => entry.slug === slug);
+
+  if (!note) {
+    return undefined;
+  }
+
+  return {
+    slug,
+    name: skill.name,
+    summary: note.summary,
+    updated: note.updated,
+    html: await renderNoteHtml(note.body),
+  };
+}

--- a/app/lib/skillDirectory.test.ts
+++ b/app/lib/skillDirectory.test.ts
@@ -1,11 +1,22 @@
 import { describe, expect, it } from "vitest";
 import { CATEGORY_ORDER, skills } from "../config/skills";
+import { joinCatalogue, type SkillNote } from "./skillCatalogue";
 import {
   buildSkillDirectory,
   getSkillDirectory,
   groupCountLabel,
   skillNoteHref,
 } from "./skillDirectory";
+
+function catalogueWithNotes(...slugs: string[]) {
+  const notes: SkillNote[] = slugs.map((slug) => ({
+    slug,
+    summary: `${slug} summary`,
+    body: "",
+  }));
+
+  return joinCatalogue(skills, notes);
+}
 
 describe("skill directory", () => {
   it("groups the catalogue in CATEGORY_ORDER", () => {
@@ -27,17 +38,8 @@ describe("skill directory", () => {
     );
   });
 
-  it("lists every skill without a note while the publish set is empty", () => {
-    const directory = getSkillDirectory();
-
-    expect(directory.every((group) => group.noted === 0)).toBe(true);
-    expect(
-      directory.every((group) => group.skills.every((s) => !s.hasNote)),
-    ).toBe(true);
-  });
-
-  it("marks note presence from the publish set it is given", () => {
-    const directory = buildSkillDirectory(skills, ["ionic"]);
+  it("reads note presence from the join rather than re-deriving it", () => {
+    const directory = buildSkillDirectory(catalogueWithNotes("ionic"));
     const mobile = directory.find((group) => group.category === "Mobile");
 
     expect(mobile?.noted).toBe(1);
@@ -45,17 +47,26 @@ describe("skill directory", () => {
     expect(mobile?.skills.find((s) => s.slug === "cordova")?.hasNote).toBe(false);
   });
 
+  it("shows Ionic as the only noted skill in the shipping directory", () => {
+    const noted = getSkillDirectory().flatMap((group) =>
+      group.skills.filter((skill) => skill.hasNote).map((skill) => skill.slug),
+    );
+
+    expect(noted).toEqual(["ionic"]);
+  });
+
   it("drops a category with no skills rather than heading an empty group", () => {
     const directory = buildSkillDirectory(
-      skills.filter((skill) => skill.category !== "Design"),
-      [],
+      catalogueWithNotes().filter((skill) => skill.category !== "Design"),
     );
 
     expect(directory.map((group) => group.category)).not.toContain("Design");
   });
 
   it("counts a group as '<n> · <m> with notes'", () => {
-    const [frontend] = buildSkillDirectory(skills, ["react", "redux"]);
+    const [frontend] = buildSkillDirectory(
+      catalogueWithNotes("react", "redux"),
+    );
 
     expect(groupCountLabel(frontend)).toBe("13 · 2 with notes");
   });

--- a/app/lib/skillDirectory.ts
+++ b/app/lib/skillDirectory.ts
@@ -1,16 +1,9 @@
-import {
-  CATEGORY_ORDER,
-  skills,
-  type Skill,
-  type SkillCategory,
-} from "../config/skills";
-
-/** A catalogue skill plus whether a skill note has been published for it. */
-export type DirectorySkill = Skill & { hasNote: boolean };
+import { CATEGORY_ORDER, type SkillCategory } from "../config/skills";
+import { getSkillCatalogue, type CatalogueSkill } from "./skillCatalogue";
 
 export type SkillDirectoryGroup = {
   category: SkillCategory;
-  skills: readonly DirectorySkill[];
+  skills: readonly CatalogueSkill[];
   /** Skills in the group. */
   total: number;
   /** Of those, how many have a note. */
@@ -18,28 +11,16 @@ export type SkillDirectoryGroup = {
 };
 
 /**
- * Slugs of the skills with a published note — the publish set. Empty until the
- * first note ships, which is why every tile is listed-only today. When notes
- * arrive this constant is replaced by the build-time join over the note files;
- * nothing downstream re-derives note presence.
- */
-const PUBLISHED_NOTE_SLUGS: readonly string[] = [];
-
-/**
  * Group a catalogue into the directory shape: `CATEGORY_ORDER` outside,
- * catalogue order preserved within a group, note presence resolved once.
- * Empty categories are dropped rather than rendered as a bare heading.
+ * catalogue order preserved within a group. Note presence arrives already
+ * resolved from the join — the directory never re-derives it. Empty categories
+ * are dropped rather than rendered as a bare heading.
  */
 export function buildSkillDirectory(
-  catalogue: readonly Skill[],
-  noteSlugs: Iterable<string>,
+  catalogue: readonly CatalogueSkill[],
 ): readonly SkillDirectoryGroup[] {
-  const noted = new Set(noteSlugs);
-
   return CATEGORY_ORDER.map((category) => {
-    const groupSkills = catalogue
-      .filter((skill) => skill.category === category)
-      .map((skill) => ({ ...skill, hasNote: noted.has(skill.slug) }));
+    const groupSkills = catalogue.filter((skill) => skill.category === category);
 
     return {
       category,
@@ -52,7 +33,7 @@ export function buildSkillDirectory(
 
 /** The `/90s` skills directory: the shared catalogue in directory shape. */
 export function getSkillDirectory(): readonly SkillDirectoryGroup[] {
-  return buildSkillDirectory(skills, PUBLISHED_NOTE_SLUGS);
+  return buildSkillDirectory(getSkillCatalogue());
 }
 
 /** The heading count for a group: `<n> · <m> with notes`. */

--- a/content/skills/ionic.md
+++ b/content/skills/ionic.md
@@ -1,0 +1,25 @@
+---
+summary: Ionic helped me deliver web and mobile products from a shared Angular foundation while staying attentive to the places where each platform remained different.
+---
+
+## Where I used it
+
+I used Ionic in two lead roles where the products had to reach people across web, iOS, and Android.
+
+At Scotts Miracle-Gro, I worked on Blossom and GroConnect, a smart-gardening product used by more than 20,000 people. The application combined Angular, Ionic, and Cordova, and shipped regularly through both app stores. I improved its load time by more than 70 percent and later helped bring a family of smart-gardening devices together under the GroConnect brand and experience.
+
+At Angel Eye Health, I redesigned MilkTracker with Angular and Ionic, replacing a legacy Objective-C application with a product that could run across web, iOS, and Android. It was deployed in ten hospitals, where nurses used it as part of a clinical workflow. The technical choices therefore had to support more than interface consistency: releases needed to be dependable, testing needed to be systematic, and the application needed to behave predictably in each environment.
+
+## Why it fit
+
+Both teams already worked in Angular, and both products needed to reach the web and two mobile stores without maintaining three separate front ends. Ionic let us keep one shared application model and spend more of our effort on product behavior, usability, and delivery.
+
+That did not make the platforms identical. Cordova supplied the bridge into the native mobile environment, while Ionic gave the Angular application a cross-platform interface layer. Store distribution, device behavior, and performance still needed platform-specific attention. The advantage was not that those differences disappeared; it was that they were contained inside a largely shared product.
+
+For MilkTracker in particular, moving away from a legacy Objective-C application also made the product easier to extend across the environments the organization needed to support. Ionic fit the team, the existing web skills, and the delivery constraint of reaching all three platforms.
+
+## What it taught me
+
+Ionic taught me to evaluate cross-platform tools by the work they remove and the boundaries they leave behind. A shared codebase can reduce duplicated feature work and give a team a common way to reason about the product, but it does not remove the responsibility to test on real platforms, manage store releases, or investigate performance where the abstraction becomes thin.
+
+The lasting lesson is that technology fit is contextual. The strongest choice is not always the one with the most native control or the newest architecture. It is the one that matches the team's strengths, reaches the product's users, and leaves the risks visible enough to manage.

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -1,10 +1,10 @@
 # Project Map
 
-**What this is:** Andrew Furusawa's personal portfolio at `andrewfurusawa.dev`, deployed on Vercel. One codebase, two **presentations** of the same substance: the public modern portfolio at `/`, and a soft-secret 90s experiment at `/90s`. There is no CMS, no database, and no API — content is TypeScript modules under `app/config/`.
+**What this is:** Andrew Furusawa's personal portfolio at `andrewfurusawa.dev`, deployed on Vercel. One codebase, two **presentations** of the same substance: the public modern portfolio at `/`, and a soft-secret 90s experiment at `/90s`. There is no CMS, no database, and no API — content is TypeScript modules under `app/config/`, plus the skill notes as Markdown files under `content/skills/`, read at build time.
 
-**Stack:** Next.js 15 App Router, React 19, TypeScript 5, Tailwind v4 (PostCSS), react-icons, Vitest, Vercel Speed Insights.
+**Stack:** Next.js 15 App Router, React 19, TypeScript 5, Tailwind v4 (PostCSS), react-icons, Vitest, Vercel Speed Insights. Skill notes add a build-time Markdown pipeline: `gray-matter` plus `unified`/`remark-parse`/`remark-rehype`/`rehype-sanitize`/`rehype-stringify`. Those six run in server components only and reach no browser bundle, so they cost nothing against the initial-JS budget — no MDX, no GFM, no raw HTML.
 
-_Last updated: 2026-08-06. Update this map when architecture or ownership changes in a way that matters._
+_Last updated: 2026-08-13. Update this map when architecture or ownership changes in a way that matters._
 
 This file is orientation: how the system is shaped and why. For *where a file lives*, use [`agent-context-map.md`](agent-context-map.md). For *what is being worked on now*, use [`../PLAN.md`](../PLAN.md). For *what a word means*, use [`../CONTEXT.md`](../CONTEXT.md).
 
@@ -14,6 +14,8 @@ This file is orientation: how the system is shaped and why. For *where a file li
 |-------|----------|---------|
 | `/` | `app/(portfolio)/` + `app/components/` | Yes — indexed, in the sitemap |
 | `/90s` | `app/90s/` alone | Soft secret — crawl-allowed, `X-Robots-Tag` `noindex, nofollow`, not in the sitemap |
+| `/90s/skills/[slug]` | `app/90s/skills/[slug]/` | Same soft secret. Prerendered from the publish set; `dynamicParams = false` |
+| `/90s/[...missing]` | `app/90s/[...missing]/` | Never renders — calls `notFound()` so every stray path under `/90s` gets the experiment's 404 rather than the global one |
 | `/prototype/90s-shell` | `app/prototype/` | Throwaway; kept for reference, not a product surface |
 
 The **route-group seam is the whole architecture**. `app/layout.tsx` is deliberately slim — `<html>`, fonts, global CSS, Speed Insights, and metadata, nothing visual. Portfolio chrome (background animation, theme toggle, page padding) lives in the `(portfolio)` group so it cannot leak onto `/90s`; the experiment's chrome lives entirely in `app/90s/nineties.module.css` behind a single `.experiment` class.
@@ -30,8 +32,12 @@ Both presentations read the same data and share none of their chrome.
 | `ProfileLink` (`app/config/profileLinks.ts`) | `{ href, ariaLabel, label, Icon, openInNewTab, heroClassName? }` | `/` hero + contact, `/90s` contact |
 | Site identity (`app/config/site.ts`) | `SITE_URL`, `SITE_NAME`, `SITE_TITLE`, `SITE_DESCRIPTION`, `absoluteUrl()` | root metadata, `robots.ts`, `sitemap.ts` |
 | `pathHeaders` (`app/config/securityHeaders.ts`) | security tuples on `/:path*`; `X-Robots-Tag` on `/90s` and `/90s/:path*` | `next.config.ts` |
+| `SkillNote` (`app/lib/skillCatalogue.ts`) | `{ slug, summary, updated?, body }`, parsed from `content/skills/<slug>.md` | the note route |
+| `CatalogueSkill` (`app/lib/skillCatalogue.ts`) | `Skill & { hasNote, summary? }` — the one join of catalogue and notes | `/90s` tiles, featured-work stack tags, the note route |
 
 `app/90s/` imports *data* from `app/config/` and *nothing* from `app/components/`. Share substance, never chrome — if a change makes the experiment import a portfolio component, the change is wrong.
+
+**A note publishes by existing.** `content/skills/<slug>.md` is the whole publish decision — no `draft` flag, no list to keep in step. `getSkillCatalogue()` is the only place catalogue and notes meet; a file whose slug names no catalogue skill throws there, which fails `next build` rather than shipping a hub link to a 404.
 
 `slug` is authored, never derived — `/90s/skills/<slug>` must survive a display-name change. `category` is a closed union (Frontend · Mobile · Backend · Tooling · Design) in `CATEGORY_ORDER`; `/` ignores it. Homepage anchors are `skill-${slug}`. See [Prefactor the shared skills catalogue with authored slugs and categories](https://github.com/afurusawa/andrewfurusawa/issues/52).
 

--- a/docs/agent-context-map.md
+++ b/docs/agent-context-map.md
@@ -2,7 +2,7 @@
 
 Path inventory. **Read the one section you need, not the whole file.** For why the system is shaped this way, read [`MAP.md`](MAP.md) instead.
 
-_Last updated: 2026-08-06._
+_Last updated: 2026-08-13._
 
 ## Routes and layouts
 
@@ -13,7 +13,12 @@ _Last updated: 2026-08-06._
 | `app/(portfolio)/page.tsx` | The public homepage `/`. |
 | `app/90s/layout.tsx` | Experiment shell — wraps children in the `.experiment` class, exports its metadata. |
 | `app/90s/page.tsx` | The `/90s` page. |
-| `app/90s/metadata.ts` | Experiment layout unfurl + `noindex`; hub canonical lives on the page. |
+| `app/90s/metadata.ts` | Experiment layout unfurl + `noindex`; hub and note canonicals live on their pages. |
+| `app/90s/skills/[slug]/page.tsx` | A skill note. `generateStaticParams` from the publish set, `dynamicParams = false`. |
+| `app/90s/ExperimentNav.tsx` | The About · Work · Skills · Contact nav, shared by the hub, the notes, and the 404. |
+| `app/90s/NoteShell.tsx` | The outer shell a note and the 404 share — banner, nav, one Document Window, footer. |
+| `app/90s/not-found.tsx` | The experiment's own 404 — same shell, recovery in the last sentence. |
+| `app/90s/[...missing]/page.tsx` | Catches every unknown path under `/90s` and calls `notFound()`, so the router's own rejection of an unmatched slug can't escape to the global 404. |
 | `app/90s/nineties.module.css` | All experiment chrome. Nothing else styles `/90s`. |
 | `app/prototype/90s-shell/` | Throwaway shell variants A–D behind `?variant=`. Reference only. |
 | `public/90s/` | The hub kitsch pack — under-construction tape plus three 88×31 badges. Hub-only theater, ≤40KB, never rendered on a note route. |
@@ -31,15 +36,17 @@ Everything here is data, not markup. New content belongs in this directory, neve
 | `app/config/site.ts` | `SITE_URL`, `SITE_NAME`, `SITE_TITLE`, `SITE_DESCRIPTION`, `absoluteUrl()`. |
 | `app/config/fonts.ts` | All four Google fonts, loaded once at the root as CSS variables. |
 | `app/config/securityHeaders.ts` | Response headers, consumed by `next.config.ts`. |
+| `content/skills/` | The skill notes, one Markdown file per catalogue slug. A file here is what publishes a note; a filename with no catalogue slug fails the build. |
 
 ## Logic
 
-Pure functions, no React, no side effects — this is what the node-environment test runner can reach.
+No React — this is what the node-environment test runner can reach. Pure functions, with one exception: `skillCatalogue.ts` reads `content/skills/` from disk. That read happens at build time inside server components, and the tests run against the real files.
 
 | Path | Holds |
 |------|-------|
 | `app/lib/filterSkills.ts` | Skills filtering for the homepage filter UI. |
-| `app/lib/skillDirectory.ts` | The `/90s` skills directory shape — catalogue grouped by category with note presence resolved. The publish set is owned here; nothing else re-derives it. |
+| `app/lib/skillCatalogue.ts` | The one join: catalogue skills plus the notes on disk, and the Markdown pipeline that renders one. The publish set is owned here; nothing else re-derives it. Touches the filesystem, so it is build-time only. |
+| `app/lib/skillDirectory.ts` | The `/90s` skills directory shape — the catalogue grouped by category. Reads the join, never the filesystem. |
 
 ## Components (modern presentation only)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,16 @@
       "version": "0.1.0",
       "dependencies": {
         "@vercel/speed-insights": "2.0.0",
+        "gray-matter": "^4.0.3",
         "next": "15.5.22",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-icons": "^5.5.0"
+        "react-icons": "^5.5.0",
+        "rehype-sanitize": "^6.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "unified": "^11.0.5"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1487,6 +1493,15 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1499,6 +1514,30 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1530,6 +1569,18 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
     },
     "node_modules/@vercel/speed-insights": {
       "version": "2.0.0",
@@ -1655,6 +1706,15 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1663,6 +1723,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1685,6 +1755,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1693,6 +1773,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chownr": {
@@ -1711,6 +1821,16 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1725,6 +1845,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1733,6 +1892,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -1756,6 +1928,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1774,6 +1959,24 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/fdir": {
@@ -1816,6 +2019,103 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
@@ -1824,6 +2124,28 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/lightningcss": {
@@ -2102,6 +2424,506 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -2140,6 +2962,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
@@ -2279,6 +3107,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
@@ -2307,6 +3145,68 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rolldown": {
@@ -2348,6 +3248,19 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -2428,6 +3341,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -2441,6 +3370,29 @@
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
@@ -2544,6 +3496,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2570,6 +3542,121 @@
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vitest": {
       "version": "4.1.10",
@@ -3043,6 +4130,16 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,10 +11,16 @@
   },
   "dependencies": {
     "@vercel/speed-insights": "2.0.0",
+    "gray-matter": "^4.0.3",
     "next": "15.5.22",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "rehype-sanitize": "^6.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "unified": "^11.0.5"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
Closes #58 — the first shipping skill note at `/90s/skills/ionic`, plus the machinery the next note reuses.

## What ships

- `content/skills/ionic.md` — the note, verbatim from the spec appendix. No `updated`, so no updated line renders.
- `app/lib/skillCatalogue.ts` — the one join. Reads `content/skills/`, joins to the catalogue, and compiles Markdown with `gray-matter` + `unified`/`remark-parse`/`remark-rehype`/`rehype-sanitize`/`rehype-stringify`. Standard Markdown only; raw HTML is stripped, not rendered.
- `app/90s/skills/[slug]/` — the note route. `generateStaticParams` from the publish set, `dynamicParams = false`, self-referential canonical, `Ionic · Andrew Furusawa` unfurl with the note's summary as the description, and no `robots` key so the layout's `noindex` survives the shallow merge.
- Hub wiring — the Ionic tile is now the link (magenta bevel, `NOTE ►`); every other tile stays listed-only. Featured-work stack tags link only for slugs in the publish set. `skillDirectory.ts` no longer keeps its own publish list.

## Publishing, and the build gate

A note publishes by existing. A file whose slug names no catalogue skill throws in the loader, which fails `next build` rather than shipping a hub link to a 404 — verified by adding a bogus note file and watching the build fail, and asserted in `skillCatalogue.test.ts`.

## The one deviation worth reading

The ticket asks for both `dynamicParams = false` and the experiment's own 404 for an unknown slug. In Next 15.5 those fight: the router rejects an unmatched param before any segment renders, so a segment-level `not-found.tsx` never fires and the global "This page could not be found" is served. `app/90s/[...missing]/page.tsx` resolves it — it calls `notFound()`, which renders `app/90s/not-found.tsx` with a 404 status inside the experiment shell. `dynamicParams = false` is untouched.

Side effect: this now answers *every* stray path under `/90s`, not just note slugs, with "That note doesn't exist." Slightly wider than the ticket's wording, and the better failure — the alternative is the global 404 with none of the experiment's chrome or escape route.

## Verified against a production build

- `/90s/skills/ionic` → 200, breadcrumb `Home / Skills / Ionic`, plain `<h1>`, the three H2s in order, mono reading column on an opaque panel, `Back to the skills directory` after the note. No hub pack on the route.
- `/90s/skills/bogus` → 404 with the locked copy, the link last, same shell.
- `X-Robots-Tag: noindex, nofollow` on both; canonical `https://andrewfurusawa.dev/90s/skills/ionic`.
- 58 tests pass, `tsc --noEmit` clean.

Review notes applied: shared `NoteShell` for the note and the 404, footer garnish shortened to a short mark, the note `<h1>` moved off VT323 (display face stays for short uppercase marks only), the focus-ring recipe reconsolidated into one grouped rule, notes read once per build instead of per call, and `docs/MAP.md` updated for the new content source, routes, data contracts, and dependency budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)