### PR TITLE
Refine homepage identity and content hierarchy

### DIFF
--- a/app/components/homepage/ColourPanelObserver.tsx
+++ b/app/components/homepage/ColourPanelObserver.tsx
@@ -4,12 +4,14 @@ import { useEffect, useState, type ReactNode } from "react";
 import { homepageSections } from "../../config/homepage";
 
 /**
- * Scroll-driven colour-panel repaint. The per-section colour change *is* the
- * register; this island only writes `data-section`. Each section still paints
- * its own field colour statically, so the page is complete without the observer.
+ * Scroll-driven colour-panel state. The per-section colour change *is* the
+ * register; this island writes the active section and identity visibility.
+ * Each section still paints its own field colour statically, so the page is
+ * complete without the observer.
  */
 export function ColourPanelObserver({ children }: { children: ReactNode }) {
   const [active, setActive] = useState(homepageSections[0].id);
+  const [panelIdentityVisible, setPanelIdentityVisible] = useState(false);
 
   useEffect(() => {
     const sections = homepageSections
@@ -28,11 +30,43 @@ export function ColourPanelObserver({ children }: { children: ReactNode }) {
     );
 
     sections.forEach((section) => observer.observe(section));
-    return () => observer.disconnect();
+
+    const identity = document.querySelector<HTMLElement>("[data-homepage-identity]");
+    const desktopQuery = window.matchMedia("(min-width: 64rem)");
+    let identityObserver: IntersectionObserver | null = null;
+
+    const updateIdentityObservation = () => {
+      identityObserver?.disconnect();
+      identityObserver = null;
+
+      if (!identity || !desktopQuery.matches) {
+        setPanelIdentityVisible(false);
+        return;
+      }
+
+      identityObserver = new IntersectionObserver(
+        ([entry]) => setPanelIdentityVisible(!entry.isIntersecting),
+        { threshold: 0 },
+      );
+      identityObserver.observe(identity);
+    };
+
+    updateIdentityObservation();
+    desktopQuery.addEventListener("change", updateIdentityObservation);
+
+    return () => {
+      observer.disconnect();
+      identityObserver?.disconnect();
+      desktopQuery.removeEventListener("change", updateIdentityObservation);
+    };
   }, []);
 
   return (
-    <div className="homepage font-sans antialiased" data-section={active}>
+    <div
+      className="homepage font-sans antialiased"
+      data-section={active}
+      data-panel-identity={panelIdentityVisible ? "visible" : "hidden"}
+    >
       {children}
     </div>
   );

--- a/app/components/homepage/Homepage.tsx
+++ b/app/components/homepage/Homepage.tsx
@@ -225,9 +225,6 @@ function WhatIDo() {
             </p>
           </div>
         </div>
-        <p className="lede mt-7 max-w-prose text-xl leading-relaxed text-body">
-          {identity.lede}
-        </p>
         <p className="mt-5 max-w-prose text-[0.9375rem] leading-relaxed text-body">
           {identity.credentialLine}
         </p>
@@ -246,17 +243,22 @@ function WhatIDo() {
         </div>
         <h2
           id="what-heading"
-          className="mt-12 border-t border-strong-hairline pt-7 font-display text-2xl tracking-tight"
+          className="mt-12 border-t border-strong-hairline pt-7 font-display text-xl leading-relaxed tracking-tight"
         >
           {whatIDoHeading}
         </h2>
+        <p className="lede mt-7 max-w-prose text-xl leading-relaxed text-body">
+          {identity.lede}
+        </p>
         <ul className="mt-8 grid gap-6 md:grid-cols-3">
           {whatIDoSteps.map((step) => (
             <li key={step.title} className="border-t-2 border-ink-what py-5">
               <h3 className="font-display text-2xl tracking-tight">{step.title}</h3>
-              <p className="mt-2 text-[0.9375rem] leading-relaxed text-body">
-                {step.body}
-              </p>
+              <ul className="mt-2 list-disc space-y-1 pl-5 text-[0.9375rem] leading-relaxed text-body">
+                {step.items.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
             </li>
           ))}
         </ul>

--- a/app/components/homepage/Homepage.tsx
+++ b/app/components/homepage/Homepage.tsx
@@ -12,7 +12,7 @@ import {
   identity,
   portrait,
   recentWorkLeadIn,
-  whatIDo,
+  whatIDoSteps,
   whereIHelp,
   type HomepageSection,
 } from "../../config/homepage";
@@ -249,9 +249,16 @@ function WhatIDo() {
         >
           {section.label}
         </h2>
-        <p className="mt-5 max-w-prose text-[0.9375rem] leading-relaxed text-body">
-          {whatIDo}
-        </p>
+        <ul className="mt-8 grid gap-6 md:grid-cols-3">
+          {whatIDoSteps.map((step) => (
+            <li key={step.title} className="border-t-2 border-ink-what py-5">
+              <h3 className="font-display text-2xl tracking-tight">{step.title}</h3>
+              <p className="mt-2 text-[0.9375rem] leading-relaxed text-body">
+                {step.body}
+              </p>
+            </li>
+          ))}
+        </ul>
       </div>
     </section>
   );

--- a/app/components/homepage/Homepage.tsx
+++ b/app/components/homepage/Homepage.tsx
@@ -84,35 +84,37 @@ function ColourPanel() {
     >
       <span className="colour-panel__ghost pointer-events-none absolute -right-6 bottom-24 select-none font-display text-[13rem] leading-none tracking-tight text-white/[0.07]" />
 
-      <div className="relative">
-        <div className="flex items-center gap-4">
-          <Image
-            src={portrait.src}
-            alt=""
-            width={portrait.width}
-            height={portrait.height}
-            sizes="56px"
-            className="h-14 w-14 rounded-full object-cover ring-2 ring-white/40"
-          />
-          <div>
-            <p className="font-display text-xl tracking-tight">{identity.name}</p>
-            <p className="mt-0.5 font-mono text-xs uppercase tracking-[0.2em]">
-              {identity.line}
+      <div className="colour-panel__identity relative">
+        <div className="min-h-0 overflow-hidden">
+          <div className="flex items-center gap-4">
+            <Image
+              src={portrait.src}
+              alt=""
+              width={portrait.width}
+              height={portrait.height}
+              sizes="56px"
+              className="h-14 w-14 rounded-full object-cover ring-2 ring-white/40"
+            />
+            <div>
+              <p className="font-display text-xl tracking-tight">{identity.name}</p>
+              <p className="mt-0.5 font-mono text-xs uppercase tracking-[0.2em]">
+                {identity.line}
+              </p>
+            </div>
+          </div>
+          <div className="mt-4 flex items-center gap-2.5 border-t border-white/15 pt-4">
+            <Image
+              src={cspoBadge.src}
+              alt=""
+              width={cspoBadge.width}
+              height={cspoBadge.height}
+              sizes="32px"
+              className="h-8 w-8 shrink-0"
+            />
+            <p className="font-mono text-xs uppercase tracking-[0.14em]">
+              {identity.credential}
             </p>
           </div>
-        </div>
-        <div className="mt-4 flex items-center gap-2.5 border-t border-white/15 pt-4">
-          <Image
-            src={cspoBadge.src}
-            alt=""
-            width={cspoBadge.width}
-            height={cspoBadge.height}
-            sizes="32px"
-            className="h-8 w-8 shrink-0"
-          />
-          <p className="font-mono text-xs uppercase tracking-[0.14em]">
-            {identity.credential}
-          </p>
         </div>
       </div>
 
@@ -201,7 +203,7 @@ function WhatIDo() {
     <section id={section.id} aria-labelledby="what-heading">
       <ColourCard section={section} index={0} />
       <div className="px-6 py-12 md:px-12 lg:py-20">
-        <div className="flex flex-col gap-6 sm:flex-row sm:items-start">
+        <div className="flex flex-col gap-6 sm:flex-row sm:items-start" data-homepage-identity>
           <Image
             src={portrait.src}
             alt={portrait.alt}

--- a/app/components/homepage/Homepage.tsx
+++ b/app/components/homepage/Homepage.tsx
@@ -243,7 +243,7 @@ function WhatIDo() {
         </div>
         <h2
           id="what-heading"
-          className="mt-12 border-t border-strong-hairline pt-7 font-display text-xl leading-relaxed tracking-tight"
+          className="mt-12 border-t border-strong-hairline pt-7 font-display text-3xl leading-tight tracking-tight md:text-4xl"
         >
           {whatIDoHeading}
         </h2>

--- a/app/components/homepage/Homepage.tsx
+++ b/app/components/homepage/Homepage.tsx
@@ -12,6 +12,7 @@ import {
   identity,
   portrait,
   recentWorkLeadIn,
+  whatIDoHeading,
   whatIDoSteps,
   whereIHelp,
   type HomepageSection,
@@ -247,7 +248,7 @@ function WhatIDo() {
           id="what-heading"
           className="mt-12 border-t border-strong-hairline pt-7 font-display text-2xl tracking-tight"
         >
-          {section.label}
+          {whatIDoHeading}
         </h2>
         <ul className="mt-8 grid gap-6 md:grid-cols-3">
           {whatIDoSteps.map((step) => (

--- a/app/config/homepage.test.ts
+++ b/app/config/homepage.test.ts
@@ -3,6 +3,7 @@ import {
   homepageSections,
   howIWork,
   identity,
+  whatIDoHeading,
   whatIDoSteps,
   whereIHelp,
 } from "./homepage";
@@ -21,6 +22,12 @@ describe("homepage copy", () => {
   it("keeps the What I do panel caption compact", () => {
     expect(homepageSections[0].caption).toBe(
       "Product decisions to production code",
+    );
+  });
+
+  it("gives the What I do content a distinct heading", () => {
+    expect(whatIDoHeading).toBe(
+      "Make the problem clear before the code gets expensive.",
     );
   });
 

--- a/app/config/homepage.test.ts
+++ b/app/config/homepage.test.ts
@@ -65,16 +65,25 @@ describe("homepage copy", () => {
       lede:
         "I turn ambiguous requirements into shipped software. I run discovery with the people who use the product, write the user stories and acceptance criteria that keep a team pointed at the right thing, and stay close enough to the code to know what a request actually costs.",
       credentialLine:
-        "12+ years shipping multi-platform mobile and web software across healthcare, consumer IoT, and eduction.",
+        "12+ years shipping multi-platform mobile and web software across healthcare, consumer IoT, and education.",
       credential: "Certified Scrum Product Owner · Scrum Alliance, 2026",
     });
   });
 
   it("locks What I do, Where I help, and How I work", () => {
     expect(whatIDoSteps).toEqual([
-      { title: "Clarify", body: "Discovery, user research, usability testing" },
-      { title: "Define", body: "Wireframes, PRDs, acceptance criteria" },
-      { title: "Deliver", body: "Production code, tests, documentation, handoff" },
+      {
+        title: "Clarify",
+        items: ["Discovery", "User research", "Usability testing"],
+      },
+      {
+        title: "Define",
+        items: ["Wireframes", "PRDs", "Acceptance criteria"],
+      },
+      {
+        title: "Deliver",
+        items: ["Production code", "Tests", "Documentation", "Handoff"],
+      },
     ]);
     expect(whereIHelp.quote).toBe(
       "Most wasted engineering effort traces back to a requirement everyone thought they understood the same way.",

--- a/app/config/homepage.test.ts
+++ b/app/config/homepage.test.ts
@@ -3,7 +3,7 @@ import {
   homepageSections,
   howIWork,
   identity,
-  whatIDo,
+  whatIDoSteps,
   whereIHelp,
 } from "./homepage";
 
@@ -16,6 +16,12 @@ describe("homepage copy", () => {
       "How I work",
       "Contact",
     ]);
+  });
+
+  it("keeps the What I do panel caption compact", () => {
+    expect(homepageSections[0].caption).toBe(
+      "Product decisions to production code",
+    );
   });
 
   it("locks colour-panel figure pairs and drops them on Contact", () => {
@@ -48,18 +54,21 @@ describe("homepage copy", () => {
     expect(identity).toEqual({
       name: "Andrew Furusawa",
       line: "Product & Software Delivery Consulting",
-      location: "Inland Empire, CA · Remote",
-      lede: "I've worked both sides — product owner and engineer. So I can take either seat, or hold both when the work needs one person to.",
+      location: "Inland Empire, CA",
+      lede:
+        "I turn ambiguous requirements into shipped software. I run discovery with the people who use the product, write the user stories and acceptance criteria that keep a team pointed at the right thing, and stay close enough to the code to know what a request actually costs.",
       credentialLine:
-        "12+ years shipping multi-platform mobile and web software. B.S. Information & Computer Science, UC Irvine.",
+        "12+ years shipping multi-platform mobile and web software across healthcare, consumer IoT, and eduction.",
       credential: "Certified Scrum Product Owner · Scrum Alliance, 2026",
     });
   });
 
   it("locks What I do, Where I help, and How I work", () => {
-    expect(whatIDo).toBe(
-      "I take software products from concept to production in weeks instead of quarters, running the engineering process a full team would use. Agentic coding and LLM-assisted workflows set the pace. Scoped requirements, written acceptance criteria, code review, and test coverage are what keep it solid. Speed and quality are the same problem, not a tradeoff. What I hand off is something your engineers can own.",
-    );
+    expect(whatIDoSteps).toEqual([
+      { title: "Clarify", body: "Discovery, user research, usability testing" },
+      { title: "Define", body: "Wireframes, PRDs, acceptance criteria" },
+      { title: "Deliver", body: "Production code, tests, documentation, handoff" },
+    ]);
     expect(whereIHelp.quote).toBe(
       "Most wasted engineering effort traces back to a requirement everyone thought they understood the same way.",
     );

--- a/app/config/homepage.ts
+++ b/app/config/homepage.ts
@@ -6,15 +6,19 @@
 export const identity = {
   name: "Andrew Furusawa",
   line: "Product & Software Delivery Consulting",
-  location: "Inland Empire, CA · Remote",
-  lede: "I've worked both sides — product owner and engineer. So I can take either seat, or hold both when the work needs one person to.",
+  location: "Inland Empire, CA",
+  lede:
+    "I turn ambiguous requirements into shipped software. I run discovery with the people who use the product, write the user stories and acceptance criteria that keep a team pointed at the right thing, and stay close enough to the code to know what a request actually costs.",
   credentialLine:
-    "12+ years shipping multi-platform mobile and web software. B.S. Information & Computer Science, UC Irvine.",
+    "12+ years shipping multi-platform mobile and web software across healthcare, consumer IoT, and eduction.",
   credential: "Certified Scrum Product Owner · Scrum Alliance, 2026",
 } as const;
 
-export const whatIDo =
-  "I take software products from concept to production in weeks instead of quarters, running the engineering process a full team would use. Agentic coding and LLM-assisted workflows set the pace. Scoped requirements, written acceptance criteria, code review, and test coverage are what keep it solid. Speed and quality are the same problem, not a tradeoff. What I hand off is something your engineers can own.";
+export const whatIDoSteps = [
+  { title: "Clarify", body: "Discovery, user research, usability testing" },
+  { title: "Define", body: "Wireframes, PRDs, acceptance criteria" },
+  { title: "Deliver", body: "Production code, tests, documentation, handoff" },
+] as const;
 
 export const whereIHelp = {
   quote:

--- a/app/config/homepage.ts
+++ b/app/config/homepage.ts
@@ -96,8 +96,7 @@ export const homepageSections: readonly HomepageSection[] = [
   {
     id: "what",
     label: "What I do",
-    caption:
-      "I take software products from concept to production in weeks instead of quarters, running the engineering process a full team would use.",
+    caption: "Product decisions to production code",
     figures: [
       { value: "12+", label: "years shipping software" },
       { value: "3", label: "industries: healthcare, IoT, education" },

--- a/app/config/homepage.ts
+++ b/app/config/homepage.ts
@@ -20,6 +20,9 @@ export const whatIDoSteps = [
   { title: "Deliver", body: "Production code, tests, documentation, handoff" },
 ] as const;
 
+export const whatIDoHeading =
+  "Make the problem clear before the code gets expensive.";
+
 export const whereIHelp = {
   quote:
     "Most wasted engineering effort traces back to a requirement everyone thought they understood the same way.",

--- a/app/config/homepage.ts
+++ b/app/config/homepage.ts
@@ -10,14 +10,23 @@ export const identity = {
   lede:
     "I turn ambiguous requirements into shipped software. I run discovery with the people who use the product, write the user stories and acceptance criteria that keep a team pointed at the right thing, and stay close enough to the code to know what a request actually costs.",
   credentialLine:
-    "12+ years shipping multi-platform mobile and web software across healthcare, consumer IoT, and eduction.",
+    "12+ years shipping multi-platform mobile and web software across healthcare, consumer IoT, and education.",
   credential: "Certified Scrum Product Owner · Scrum Alliance, 2026",
 } as const;
 
 export const whatIDoSteps = [
-  { title: "Clarify", body: "Discovery, user research, usability testing" },
-  { title: "Define", body: "Wireframes, PRDs, acceptance criteria" },
-  { title: "Deliver", body: "Production code, tests, documentation, handoff" },
+  {
+    title: "Clarify",
+    items: ["Discovery", "User research", "Usability testing"],
+  },
+  {
+    title: "Define",
+    items: ["Wireframes", "PRDs", "Acceptance criteria"],
+  },
+  {
+    title: "Deliver",
+    items: ["Production code", "Tests", "Documentation", "Handoff"],
+  },
 ] as const;
 
 export const whatIDoHeading =

--- a/app/globals.css
+++ b/app/globals.css
@@ -247,6 +247,23 @@ body {
   transition-duration: 500ms;
 }
 
+@media (min-width: 64rem) {
+  .colour-panel__identity {
+    display: grid;
+    grid-template-rows: 0fr;
+    opacity: 0;
+    transform: translateY(-0.5rem);
+    transition-property: grid-template-rows, opacity, transform;
+    transition-duration: 350ms;
+  }
+
+  .homepage[data-panel-identity="visible"] .colour-panel__identity {
+    grid-template-rows: 1fr;
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .colour-panel__ghost::before {
   content: var(--panel-numeral);
 }
@@ -293,6 +310,7 @@ body {
 
 @media (prefers-reduced-motion: reduce) {
   .colour-panel,
+  .colour-panel__identity,
   .progress-seg,
   .section-index__rule {
     transition-duration: 0s;


### PR DESCRIPTION
## Summary

- Keep the left identity panel hidden while the right-side identity block is in view, then reveal it after the block scrolls away on desktop.
- Reduce the left panel caption to `Product decisions to production code`.
- Replace duplicated homepage copy with a clearer opening and Clarify, Define, and Deliver lists.
- Move the opening beneath the section tagline, correct `education`, and match the tagline to the page's larger quote type scale.

## Verification

- `pnpm test` (67 tests)
- `pnpm exec tsc --noEmit`
- `pnpm build`
- Desktop and mobile preview checks